### PR TITLE
ci: enforce cross-package version sync

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -168,19 +168,11 @@ jobs:
             echo "Auto-bumping patch: $CURRENT -> $NEW_VERSION"
           fi
 
-      - name: Update Cargo.toml version
+      - name: Sync all package versions
         if: steps.check-label.outputs.skip != 'true' && steps.release.outputs.needs_bump == 'true'
         run: |
           VERSION="${{ steps.release.outputs.version }}"
-
-          # Update version in all workspace member packages
-          for package in ailoop-core ailoop-cli; do
-            if [ -f "${package}/Cargo.toml" ]; then
-              sed -i "s/^version = \".*\"/version = \"$VERSION\"/" "${package}/Cargo.toml"
-              echo "Updated ${package}/Cargo.toml to version $VERSION:"
-              grep '^version = ' "${package}/Cargo.toml"
-            fi
-          done
+          bash scripts/sync-versions.sh "$VERSION"
 
       - name: Commit version bump
         if: steps.check-label.outputs.skip != 'true' && steps.release.outputs.needs_bump == 'true'
@@ -190,8 +182,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Add all modified Cargo.toml files from workspace members
-          git add ailoop-core/Cargo.toml ailoop-cli/Cargo.toml
+          git add \
+            ailoop-core/Cargo.toml \
+            ailoop-cli/Cargo.toml \
+            ailoop-py/pyproject.toml \
+            ailoop-js/package.json \
+            ailoop-js/package-lock.json
           git commit -m "chore: bump version to $VERSION [skip ci]"
           git push origin HEAD:refs/heads/main
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,17 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  verify-versions:
+    name: Verify package versions match
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Verify versions
+      run: bash scripts/check-versions.sh
+
   test-rust:
     name: Test Rust
     runs-on: ubuntu-latest

--- a/ailoop-js/package-lock.json
+++ b/ailoop-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ailoop-js",
-  "version": "0.1.1",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ailoop-js",
-      "version": "0.1.1",
+      "version": "0.1.5",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "axios": "^1.6.0",

--- a/ailoop-js/package.json
+++ b/ailoop-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ailoop-js",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "TypeScript SDK for ailoop server communication",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/ailoop-py/pyproject.toml
+++ b/ailoop-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ailoop-py"
-version = "0.1.4"
+version = "0.1.5"
 description = "Python SDK for ailoop server communication"
 readme = "README.md"
 license = {text = "MIT OR Apache-2.0"}

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+core="$(grep -m1 '^version = ' ailoop-core/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')"
+cli="$(grep -m1 '^version = ' ailoop-cli/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')"
+py="$(grep -m1 '^version = ' ailoop-py/pyproject.toml | sed -E 's/version = "([^"]+)"/\1/')"
+js="$(node -p "require('./ailoop-js/package.json').version")"
+lock="$(node -p "require('./ailoop-js/package-lock.json').version")"
+
+fail=0
+
+check_eq() {
+  local name="$1"
+  local val="$2"
+  if [[ "$val" != "$core" ]]; then
+    echo "version mismatch: $name=$val core=$core" >&2
+    fail=1
+  fi
+}
+
+check_eq "ailoop-cli" "$cli"
+check_eq "ailoop-py" "$py"
+check_eq "ailoop-js" "$js"
+check_eq "ailoop-js:package-lock" "$lock"
+
+if [[ "$fail" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "ok: all versions match $core"

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+
+if [[ -z "$VERSION" ]]; then
+  VERSION="$(grep -m1 '^version = ' ailoop-core/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')"
+fi
+
+if [[ -z "$VERSION" ]]; then
+  echo "error: could not determine version" >&2
+  exit 1
+fi
+
+echo "Syncing versions to: $VERSION"
+
+# Rust (workspace members)
+for f in ailoop-core/Cargo.toml ailoop-cli/Cargo.toml; do
+  sed -i -E "s/^version = \"[^\"]+\"/version = \"$VERSION\"/" "$f"
+done
+
+# Python (pyproject)
+sed -i -E "s/^version = \"[^\"]+\"/version = \"$VERSION\"/" ailoop-py/pyproject.toml
+
+# TypeScript (package.json + package-lock.json) via npm to keep lockfile consistent
+(
+  cd ailoop-js
+  current="$(node -p "require('./package.json').version")"
+  if [[ "$current" != "$VERSION" ]]; then
+    npm version "$VERSION" --no-git-tag-version
+  fi
+  npm install --package-lock-only --ignore-scripts
+)


### PR DESCRIPTION
## Summary
- Add scripts to sync/check versions with ailoop-core as the source of truth.
- Add CI job to fail early on version drift.
- Update auto-release to sync Rust/Python/TypeScript (and package-lock.json) when bumping.

## Test plan
- [ ] CI passes (verify-versions + existing jobs)
- [ ] Auto-release bump updates all manifests
- [ ] Release workflow verify-version step passes