### PR TITLE
chore: update ailoop-py lock file to version 0.1.23

### DIFF
--- a/ailoop-py/uv.lock
+++ b/ailoop-py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ailoop-py"
-version = "0.1.9"
+version = "0.1.23"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Updated ailoop-py version in uv.lock from 0.1.9 to 0.1.23
- Part of iteration 4 work in progress

## Changes
- Bumped version in `ailoop-py/uv.lock`