### PR TITLE
chore(python): bump version to 0.1.25 in uv.lock

### DIFF
--- a/ailoop-py/uv.lock
+++ b/ailoop-py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ailoop-py"
-version = "0.1.24"
+version = "0.1.25"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bumps ailoop-py version from 0.1.24 to 0.1.25 in uv.lock file

## Changes
- Updated ailoop-py/uv.lock to reflect version 0.1.25