### PR TITLE
fix: fix terminal countdown prompt cleanup

### DIFF
--- a/ailoop-cli/Cargo.toml
+++ b/ailoop-cli/Cargo.toml
@@ -29,6 +29,7 @@ tracing-subscriber = { workspace = true }
 toml = { workspace = true }
 url = { workspace = true }
 async-trait = { workspace = true }
+crossterm = { workspace = true }
 
 [dev-dependencies]
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }

--- a/ailoop-cli/src/cli/handlers.rs
+++ b/ailoop-cli/src/cli/handlers.rs
@@ -2,6 +2,10 @@
 
 use anyhow::{Context, Result};
 use std::io::{self, IsTerminal, Write};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::Duration;
 use tokio::signal;
 
@@ -195,10 +199,18 @@ pub async fn handle_ask(
         let response = if timeout_secs > 0 {
             let timeout_duration = Duration::from_secs(timeout_secs as u64);
             let timeout_secs_val = timeout_secs;
+            let cancelled = Arc::new(AtomicBool::new(false));
+            let mut input_task = tokio::task::spawn_blocking({
+                let cancelled = Arc::clone(&cancelled);
+                move || {
+                    crate::cli::terminal_input::read_user_input_with_countdown(
+                        timeout_duration,
+                        cancelled,
+                    )
+                }
+            });
             tokio::select! {
-                result = tokio::task::spawn_blocking(move || {
-                    crate::cli::terminal_input::read_user_input_with_countdown(timeout_duration)
-                }) => {
+                result = &mut input_task => {
                     match result {
                         Ok(Ok(ailoop_core::terminal::countdown::InputResult::Submitted(answer))) => answer,
                         Ok(Ok(ailoop_core::terminal::countdown::InputResult::Timeout)) => {
@@ -241,6 +253,7 @@ pub async fn handle_ask(
                     }
                 }
                 _ = signal::ctrl_c() => {
+                    stop_terminal_input(&cancelled, &mut input_task).await;
                     if json {
                         let error_response = serde_json::json!({
                             "error": "cancelled",
@@ -304,6 +317,14 @@ async fn read_user_input() -> Result<String> {
     .await
     .context("Failed to read user input")?
     .context("Failed to read from stdin")
+}
+
+async fn stop_terminal_input<T>(
+    cancelled: &Arc<AtomicBool>,
+    handle: &mut tokio::task::JoinHandle<Result<T>>,
+) {
+    cancelled.store(true, Ordering::Relaxed);
+    let _ = handle.await;
 }
 
 /// Handle the 'authorize' command
@@ -467,10 +488,18 @@ pub async fn handle_authorize(
 
     let decision = if timeout_secs > 0 {
         let timeout_duration = Duration::from_secs(timeout_secs as u64);
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let mut input_task = tokio::task::spawn_blocking({
+            let cancelled = Arc::clone(&cancelled);
+            move || {
+                crate::cli::terminal_input::read_user_input_with_countdown(
+                    timeout_duration,
+                    cancelled,
+                )
+            }
+        });
         tokio::select! {
-            result = tokio::task::spawn_blocking(move || {
-                crate::cli::terminal_input::read_user_input_with_countdown(timeout_duration)
-            }) => {
+            result = &mut input_task => {
                 match result {
                     Ok(Ok(ailoop_core::terminal::countdown::InputResult::Submitted(answer))) => {
                         parse_authorization_response(&answer, default_yes)?
@@ -514,6 +543,7 @@ pub async fn handle_authorize(
                 }
             }
             _ = signal::ctrl_c() => {
+                stop_terminal_input(&cancelled, &mut input_task).await;
                 if json {
                     let error_response = serde_json::json!({
                         "authorized": false,

--- a/ailoop-cli/src/cli/handlers.rs
+++ b/ailoop-cli/src/cli/handlers.rs
@@ -1,7 +1,7 @@
 //! CLI command handlers
 
 use anyhow::{Context, Result};
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::time::Duration;
 use tokio::signal;
 
@@ -448,11 +448,12 @@ pub async fn handle_authorize(
     }
 
     // Direct mode: display the authorization request locally
+    let is_tty = io::stdin().is_terminal() && io::stdout().is_terminal();
     println!("Authorization Request");
     println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     println!("Action: {}", action);
     println!("Channel: {}", channel);
-    if timeout_secs > 0 {
+    if timeout_secs > 0 && !is_tty {
         println!("Timeout: {} seconds", timeout_secs);
     }
     println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");

--- a/ailoop-cli/src/cli/handlers.rs
+++ b/ailoop-cli/src/cli/handlers.rs
@@ -4,7 +4,6 @@ use anyhow::{Context, Result};
 use std::io::{self, Write};
 use std::time::Duration;
 use tokio::signal;
-use tokio::time::timeout;
 
 /// Handle the 'ask' command
 pub async fn handle_ask(
@@ -190,34 +189,57 @@ pub async fn handle_ask(
         }
     } else {
         // Direct mode: display the question locally
+        if timeout_secs > 0 {
+            println!("Timeout: {} seconds", timeout_secs);
+        }
         print!("Question: {}: ", question);
         io::stdout().flush().context("Failed to flush stdout")?;
 
-        // Collect response with optional timeout and Ctrl+C handling
         let response = if timeout_secs > 0 {
             let timeout_duration = Duration::from_secs(timeout_secs as u64);
+            let timeout_secs_val = timeout_secs;
             tokio::select! {
-                result = timeout(timeout_duration, read_user_input()) => {
+                result = tokio::task::spawn_blocking(move || {
+                    crate::cli::terminal_input::read_user_input_with_countdown(timeout_duration)
+                }) => {
                     match result {
-                        Ok(Ok(answer)) => answer,
-                        Ok(Err(e)) => return Err(e),
-                        Err(_) => {
-                            // Timeout occurred
+                        Ok(Ok(ailoop_core::terminal::countdown::InputResult::Submitted(answer))) => answer,
+                        Ok(Ok(ailoop_core::terminal::countdown::InputResult::Timeout)) => {
                             if json {
                                 let error_response = serde_json::json!({
                                     "error": "timeout",
-                                    "message": format!("Question timed out after {} seconds", timeout_secs),
+                                    "message": format!("Question timed out after {} seconds", timeout_secs_val),
                                     "channel": channel,
                                     "timestamp": chrono::Utc::now().to_rfc3339()
                                 });
                                 println!("\n{}", serde_json::to_string_pretty(&error_response)?);
                             } else {
-                                println!("\nTimeout: No response received within {} seconds", timeout_secs);
+                                println!("\nTimeout: No response received within {} seconds", timeout_secs_val);
                             }
                             return Err(anyhow::anyhow!(
                                 "Question timed out after {} seconds",
-                                timeout_secs
+                                timeout_secs_val
                             ));
+                        }
+                        Ok(Ok(ailoop_core::terminal::countdown::InputResult::Cancelled)) => {
+                            if json {
+                                let error_response = serde_json::json!({
+                                    "error": "cancelled",
+                                    "message": "Question cancelled by user (Ctrl+C)",
+                                    "channel": channel,
+                                    "timestamp": chrono::Utc::now().to_rfc3339()
+                                });
+                                println!("\n{}", serde_json::to_string_pretty(&error_response)?);
+                            } else {
+                                println!("\nCancelled by user");
+                            }
+                            return Err(anyhow::anyhow!("Cancelled by user"));
+                        }
+                        Ok(Err(_)) => {
+                            return Err(anyhow::anyhow!("Failed to read user input"));
+                        }
+                        Err(_) => {
+                            return Err(anyhow::anyhow!("Failed to read user input"));
                         }
                     }
                 }
@@ -445,19 +467,17 @@ pub async fn handle_authorize(
     print!("{}", prompt);
     io::stdout().flush().context("Failed to flush stdout")?;
 
-    // Collect response with timeout (defaults to denial) and Ctrl+C handling
     let decision = if timeout_secs > 0 {
         let timeout_duration = Duration::from_secs(timeout_secs as u64);
         tokio::select! {
-            result = timeout(timeout_duration, read_user_input()) => {
+            result = tokio::task::spawn_blocking(move || {
+                crate::cli::terminal_input::read_user_input_with_countdown(timeout_duration)
+            }) => {
                 match result {
-                    Ok(Ok(answer)) => parse_authorization_response(&answer, default_yes)?,
-                    Ok(Err(_)) => {
-                        // Read error - default to denial
-                        AuthorizationDecision::Denied
+                    Ok(Ok(ailoop_core::terminal::countdown::InputResult::Submitted(answer))) => {
+                        parse_authorization_response(&answer, default_yes)?
                     }
-                    Err(_) => {
-                        // Timeout - default to denial for security
+                    Ok(Ok(ailoop_core::terminal::countdown::InputResult::Timeout)) => {
                         if json {
                             let error_response = serde_json::json!({
                                 "authorized": false,
@@ -472,10 +492,30 @@ pub async fn handle_authorize(
                         }
                         return Err(anyhow::anyhow!("Authorization timed out"));
                     }
+                    Ok(Ok(ailoop_core::terminal::countdown::InputResult::Cancelled)) => {
+                        if json {
+                            let error_response = serde_json::json!({
+                                "authorized": false,
+                                "action": action,
+                                "channel": channel,
+                                "reason": "cancelled",
+                                "timestamp": chrono::Utc::now().to_rfc3339()
+                            });
+                            println!("\n{}", serde_json::to_string_pretty(&error_response)?);
+                        } else {
+                            println!("\nCancelled by user. Defaulting to DENIED for security.");
+                        }
+                        return Err(anyhow::anyhow!("Authorization cancelled"));
+                    }
+                    Ok(Err(_)) => {
+                        AuthorizationDecision::Denied
+                    }
+                    Err(_) => {
+                        AuthorizationDecision::Denied
+                    }
                 }
             }
             _ = signal::ctrl_c() => {
-                // Ctrl+C - default to denial for security
                 if json {
                     let error_response = serde_json::json!({
                         "authorized": false,
@@ -492,14 +532,12 @@ pub async fn handle_authorize(
             }
         }
     } else {
-        // No timeout - wait for response, but handle Ctrl+C
         tokio::select! {
             result = read_user_input() => {
                 let answer = result.context("Failed to read user input")?;
                 parse_authorization_response(&answer, default_yes)?
             }
             _ = signal::ctrl_c() => {
-                // Ctrl+C - default to denial for security
                 if json {
                     let error_response = serde_json::json!({
                         "authorized": false,

--- a/ailoop-cli/src/cli/handlers.rs
+++ b/ailoop-cli/src/cli/handlers.rs
@@ -189,9 +189,6 @@ pub async fn handle_ask(
         }
     } else {
         // Direct mode: display the question locally
-        if timeout_secs > 0 {
-            println!("Timeout: {} seconds", timeout_secs);
-        }
         print!("Question: {}: ", question);
         io::stdout().flush().context("Failed to flush stdout")?;
 

--- a/ailoop-cli/src/cli/mod.rs
+++ b/ailoop-cli/src/cli/mod.rs
@@ -8,5 +8,6 @@ pub mod provider;
 pub mod provider_handlers;
 pub mod task;
 pub mod task_handlers;
+pub mod terminal_input;
 pub mod workflow;
 pub mod workflow_handlers;

--- a/ailoop-cli/src/cli/terminal_input.rs
+++ b/ailoop-cli/src/cli/terminal_input.rs
@@ -9,11 +9,11 @@ use std::time::Duration;
 
 pub fn read_user_input_with_countdown(timeout: Duration) -> Result<InputResult> {
     if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
-        return read_user_input_fallback();
+        return read_user_input_fallback(timeout);
     }
 
     if enable_raw_mode().is_err() {
-        return read_user_input_fallback();
+        return read_user_input_fallback(timeout);
     }
 
     let result = read_with_countdown_inner(timeout);
@@ -87,10 +87,16 @@ fn read_with_countdown_inner(timeout: Duration) -> Result<InputResult> {
     }
 }
 
-fn read_user_input_fallback() -> Result<InputResult> {
-    let mut buffer = String::new();
-    io::stdin()
-        .read_line(&mut buffer)
-        .context("Failed to read from stdin")?;
-    Ok(InputResult::Submitted(buffer.trim().to_string()))
+fn read_user_input_fallback(timeout: Duration) -> Result<InputResult> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buffer = String::new();
+        let result = io::stdin().read_line(&mut buffer);
+        let _ = tx.send(result.map(|_| buffer));
+    });
+    match rx.recv_timeout(timeout) {
+        Ok(Ok(buffer)) => Ok(InputResult::Submitted(buffer.trim().to_string())),
+        Ok(Err(e)) => Err(e).context("Failed to read from stdin"),
+        Err(_) => Ok(InputResult::Timeout),
+    }
 }

--- a/ailoop-cli/src/cli/terminal_input.rs
+++ b/ailoop-cli/src/cli/terminal_input.rs
@@ -5,9 +5,16 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode},
 };
 use std::io::{self, IsTerminal, Write};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::Duration;
 
-pub fn read_user_input_with_countdown(timeout: Duration) -> Result<InputResult> {
+pub fn read_user_input_with_countdown(
+    timeout: Duration,
+    cancelled: Arc<AtomicBool>,
+) -> Result<InputResult> {
     if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
         return read_user_input_fallback(timeout);
     }
@@ -16,24 +23,30 @@ pub fn read_user_input_with_countdown(timeout: Duration) -> Result<InputResult> 
         return read_user_input_fallback(timeout);
     }
 
-    let result = read_with_countdown_inner(timeout);
+    let result = read_with_countdown_inner(timeout, cancelled);
     disable_raw_mode().ok();
     result
 }
 
-fn read_with_countdown_inner(timeout: Duration) -> Result<InputResult> {
+fn read_with_countdown_inner(timeout: Duration, cancelled: Arc<AtomicBool>) -> Result<InputResult> {
     let mut buffer = String::new();
     let mut countdown = CountdownRenderer::new(timeout);
+    let mut countdown_enabled = true;
 
     println!("\x1B[s");
     io::stdout().flush().ok();
 
     loop {
-        let elapsed = countdown.remaining_secs();
-        if elapsed == 0 {
+        if cancelled.load(Ordering::Relaxed) {
             print!("\r\x1B[2K\x1B[u");
             io::stdout().flush().ok();
             println!();
+            return Ok(InputResult::Cancelled);
+        }
+
+        if countdown.remaining_secs() == 0 {
+            print!("{}", countdown.render_final());
+            io::stdout().flush().ok();
             return Ok(InputResult::Timeout);
         }
 
@@ -70,10 +83,14 @@ fn read_with_countdown_inner(timeout: Duration) -> Result<InputResult> {
                 }
             }
             Ok(false) => {
-                if let Some(update) = countdown.render_update() {
-                    let mut stdout = io::stdout();
-                    if stdout.write_all(update.as_bytes()).is_ok() {
-                        let _ = stdout.flush();
+                if countdown_enabled {
+                    if let Some(update) = countdown.render_update() {
+                        let mut stdout = io::stdout();
+                        if stdout.write_all(update.as_bytes()).is_ok() {
+                            let _ = stdout.flush();
+                        } else {
+                            countdown_enabled = false;
+                        }
                     }
                 }
             }

--- a/ailoop-cli/src/cli/terminal_input.rs
+++ b/ailoop-cli/src/cli/terminal_input.rs
@@ -25,9 +25,14 @@ fn read_with_countdown_inner(timeout: Duration) -> Result<InputResult> {
     let mut buffer = String::new();
     let mut countdown = CountdownRenderer::new(timeout);
 
+    println!("\x1B[s");
+    io::stdout().flush().ok();
+
     loop {
         let elapsed = countdown.remaining_secs();
         if elapsed == 0 {
+            print!("\r\x1B[2K\x1B[u");
+            io::stdout().flush().ok();
             println!();
             return Ok(InputResult::Timeout);
         }
@@ -38,22 +43,25 @@ fn read_with_countdown_inner(timeout: Duration) -> Result<InputResult> {
                     if key_event.kind == KeyEventKind::Press {
                         match key_event.code {
                             KeyCode::Enter => {
+                                print!("\r\x1B[2K\x1B[u");
+                                io::stdout().flush().ok();
                                 println!();
-                                let answer = buffer.trim().to_string();
-                                return Ok(InputResult::Submitted(answer));
+                                return Ok(InputResult::Submitted(buffer.trim().to_string()));
                             }
                             KeyCode::Esc => {
+                                print!("\r\x1B[2K\x1B[u");
+                                io::stdout().flush().ok();
                                 println!();
                                 return Ok(InputResult::Cancelled);
                             }
                             KeyCode::Char(c) => {
                                 buffer.push(c);
-                                print!("{}", c);
+                                print!("\x1B[u{}\x1B[s\x1B[B\r", c);
                                 io::stdout().flush().ok();
                             }
                             KeyCode::Backspace if !buffer.is_empty() => {
                                 buffer.pop();
-                                print!("\x08 \x08");
+                                print!("\x1B[u\x08 \x08\x1B[s\x1B[B\r");
                                 io::stdout().flush().ok();
                             }
                             _ => {}
@@ -70,6 +78,9 @@ fn read_with_countdown_inner(timeout: Duration) -> Result<InputResult> {
                 }
             }
             Err(_) => {
+                print!("\r\x1B[2K\x1B[u");
+                io::stdout().flush().ok();
+                println!();
                 return Ok(InputResult::Timeout);
             }
         }

--- a/ailoop-cli/src/cli/terminal_input.rs
+++ b/ailoop-cli/src/cli/terminal_input.rs
@@ -1,0 +1,85 @@
+use ailoop_core::terminal::countdown::{CountdownRenderer, InputResult};
+use anyhow::{Context, Result};
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    terminal::{disable_raw_mode, enable_raw_mode},
+};
+use std::io::{self, IsTerminal, Write};
+use std::time::Duration;
+
+pub fn read_user_input_with_countdown(timeout: Duration) -> Result<InputResult> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return read_user_input_fallback();
+    }
+
+    if enable_raw_mode().is_err() {
+        return read_user_input_fallback();
+    }
+
+    let result = read_with_countdown_inner(timeout);
+    disable_raw_mode().ok();
+    result
+}
+
+fn read_with_countdown_inner(timeout: Duration) -> Result<InputResult> {
+    let mut buffer = String::new();
+    let mut countdown = CountdownRenderer::new(timeout);
+
+    loop {
+        let elapsed = countdown.remaining_secs();
+        if elapsed == 0 {
+            println!();
+            return Ok(InputResult::Timeout);
+        }
+
+        match event::poll(Duration::from_millis(100)) {
+            Ok(true) => {
+                if let Ok(Event::Key(key_event)) = event::read() {
+                    if key_event.kind == KeyEventKind::Press {
+                        match key_event.code {
+                            KeyCode::Enter => {
+                                println!();
+                                let answer = buffer.trim().to_string();
+                                return Ok(InputResult::Submitted(answer));
+                            }
+                            KeyCode::Esc => {
+                                println!();
+                                return Ok(InputResult::Cancelled);
+                            }
+                            KeyCode::Char(c) => {
+                                buffer.push(c);
+                                print!("{}", c);
+                                io::stdout().flush().ok();
+                            }
+                            KeyCode::Backspace if !buffer.is_empty() => {
+                                buffer.pop();
+                                print!("\x08 \x08");
+                                io::stdout().flush().ok();
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            Ok(false) => {
+                if let Some(update) = countdown.render_update() {
+                    let mut stdout = io::stdout();
+                    if stdout.write_all(update.as_bytes()).is_ok() {
+                        let _ = stdout.flush();
+                    }
+                }
+            }
+            Err(_) => {
+                return Ok(InputResult::Timeout);
+            }
+        }
+    }
+}
+
+fn read_user_input_fallback() -> Result<InputResult> {
+    let mut buffer = String::new();
+    io::stdin()
+        .read_line(&mut buffer)
+        .context("Failed to read from stdin")?;
+    Ok(InputResult::Submitted(buffer.trim().to_string()))
+}

--- a/ailoop-core/src/lib.rs
+++ b/ailoop-core/src/lib.rs
@@ -24,5 +24,6 @@ pub mod models;
 pub mod parser;
 pub mod server;
 pub mod services;
+pub mod terminal;
 pub mod transport;
 pub mod workflow;

--- a/ailoop-core/src/server/core.rs
+++ b/ailoop-core/src/server/core.rs
@@ -12,7 +12,10 @@ use crossterm::{
 use futures_util::{SinkExt, StreamExt};
 use std::future::Future;
 use std::io::{self, IsTerminal, Write};
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use tokio::net::TcpListener;
 use tokio::time::{interval, Duration};
 use tokio_tungstenite::{accept_async, tungstenite::Message as WsMessage};
@@ -471,10 +474,15 @@ impl AiloopServer {
         };
 
         let (answer_text, response_type, selected_index) = if use_terminal {
+            let terminal_cancelled = Arc::new(AtomicBool::new(false));
+            let mut terminal_input = tokio::task::spawn_blocking({
+                let terminal_cancelled = Arc::clone(&terminal_cancelled);
+                move || Self::read_user_input_with_esc(timeout_duration, terminal_cancelled)
+            });
             tokio::select! {
-                result = Self::read_user_input_with_esc(timeout_duration) => {
+                result = &mut terminal_input => {
                     match result {
-                        Ok(Some(text)) => {
+                        Ok(Ok(Some(text))) => {
                             let (final_answer, index) = Self::process_answer(&text, &choices);
                             let content = MessageContent::Response {
                                 answer: Some(final_answer.clone()),
@@ -483,7 +491,7 @@ impl AiloopServer {
                             completer.complete(content).await;
                             (Some(final_answer), ResponseType::Text, index)
                         }
-                        Ok(None) => {
+                        Ok(Ok(None)) => {
                             println!("\nQuestion skipped");
                             let content = MessageContent::Response {
                                 answer: None,
@@ -491,6 +499,14 @@ impl AiloopServer {
                             };
                             completer.complete(content).await;
                             (None, ResponseType::Cancelled, None)
+                        }
+                        Ok(Err(_)) => {
+                            let content = MessageContent::Response {
+                                answer: None,
+                                response_type: ResponseType::Timeout,
+                            };
+                            completer.complete(content).await;
+                            (None, ResponseType::Timeout, None)
                         }
                         Err(_) => {
                             let content = MessageContent::Response {
@@ -503,6 +519,7 @@ impl AiloopServer {
                     }
                 }
                 result = PendingPromptRegistry::recv_with_timeout(rx, timeout_duration) => {
+                    Self::stop_terminal_prompt(&terminal_cancelled, &mut terminal_input).await;
                     match result {
                         Ok(MessageContent::Response { answer, response_type }) => {
                             let index = answer.as_ref().and_then(|a| {
@@ -532,6 +549,7 @@ impl AiloopServer {
                     }
                 }
                 _ = tokio::signal::ctrl_c() => {
+                    Self::stop_terminal_prompt(&terminal_cancelled, &mut terminal_input).await;
                     println!("\n Cancelled");
                     let content = MessageContent::Response {
                         answer: None,
@@ -669,10 +687,15 @@ impl AiloopServer {
         };
 
         let decision = if use_terminal {
+            let terminal_cancelled = Arc::new(AtomicBool::new(false));
+            let mut terminal_input = tokio::task::spawn_blocking({
+                let terminal_cancelled = Arc::clone(&terminal_cancelled);
+                move || Self::read_authorization_with_esc(timeout_duration, terminal_cancelled)
+            });
             tokio::select! {
-                result = Self::read_authorization_with_esc(timeout_duration) => {
+                result = &mut terminal_input => {
                     match result {
-                        Ok(Some(response_type)) => {
+                        Ok(Ok(Some(response_type))) => {
                             let content = MessageContent::Response {
                                 answer: None,
                                 response_type: response_type.clone(),
@@ -680,7 +703,7 @@ impl AiloopServer {
                             completer.complete(content).await;
                             response_type
                         }
-                        Ok(None) => {
+                        Ok(Ok(None)) => {
                             println!("\nAuthorization skipped");
                             completer
                                 .complete(MessageContent::Response {
@@ -689,6 +712,15 @@ impl AiloopServer {
                                 })
                                 .await;
                             ResponseType::Cancelled
+                        }
+                        Ok(Err(_)) => {
+                            completer
+                                .complete(MessageContent::Response {
+                                    answer: None,
+                                    response_type: ResponseType::AuthorizationDenied,
+                                })
+                                .await;
+                            ResponseType::AuthorizationDenied
                         }
                         Err(_) => {
                             completer
@@ -702,6 +734,7 @@ impl AiloopServer {
                     }
                 }
                 result = PendingPromptRegistry::recv_with_timeout(rx, timeout_duration) => {
+                    Self::stop_terminal_prompt(&terminal_cancelled, &mut terminal_input).await;
                     match result {
                         Ok(MessageContent::Response { response_type, .. }) => response_type,
                         _ => {
@@ -717,6 +750,7 @@ impl AiloopServer {
                     }
                 }
                 _ = tokio::signal::ctrl_c() => {
+                    Self::stop_terminal_prompt(&terminal_cancelled, &mut terminal_input).await;
                     println!("\nCancelled - DENIED");
                     completer
                         .complete(MessageContent::Response {
@@ -819,10 +853,15 @@ impl AiloopServer {
             .await;
 
         let decision = if use_terminal {
+            let terminal_cancelled = Arc::new(AtomicBool::new(false));
+            let mut terminal_input = tokio::task::spawn_blocking({
+                let terminal_cancelled = Arc::clone(&terminal_cancelled);
+                move || Self::read_authorization_with_esc(default_timeout, terminal_cancelled)
+            });
             tokio::select! {
-                result = Self::read_authorization_with_esc(default_timeout) => {
+                result = &mut terminal_input => {
                     match result {
-                        Ok(Some(response_type)) => {
+                        Ok(Ok(Some(response_type))) => {
                             let content = MessageContent::Response {
                                 answer: None,
                                 response_type: response_type.clone(),
@@ -830,8 +869,17 @@ impl AiloopServer {
                             completer.complete(content).await;
                             response_type
                         }
-                        Ok(None) => {
+                        Ok(Ok(None)) => {
                             println!("\nNavigation skipped");
+                            completer
+                                .complete(MessageContent::Response {
+                                    answer: None,
+                                    response_type: ResponseType::Cancelled,
+                                })
+                                .await;
+                            ResponseType::Cancelled
+                        }
+                        Ok(Err(_)) => {
                             completer
                                 .complete(MessageContent::Response {
                                     answer: None,
@@ -852,6 +900,7 @@ impl AiloopServer {
                     }
                 }
                 result = PendingPromptRegistry::recv_with_timeout(rx, default_timeout) => {
+                    Self::stop_terminal_prompt(&terminal_cancelled, &mut terminal_input).await;
                     match result {
                         Ok(MessageContent::Response { response_type, .. }) => response_type,
                         _ => {
@@ -866,6 +915,7 @@ impl AiloopServer {
                     }
                 }
                 _ = tokio::signal::ctrl_c() => {
+                    Self::stop_terminal_prompt(&terminal_cancelled, &mut terminal_input).await;
                     println!("\n Cancelled - DENIED");
                     completer
                         .complete(MessageContent::Response {
@@ -970,137 +1020,176 @@ impl AiloopServer {
         (trimmed.to_string(), None)
     }
 
+    async fn stop_terminal_prompt<T>(
+        cancelled: &Arc<AtomicBool>,
+        handle: &mut tokio::task::JoinHandle<Result<Option<T>>>,
+    ) {
+        cancelled.store(true, Ordering::Relaxed);
+        let _ = handle.await;
+    }
+
     /// Read user input with ESC support (ESC to skip, Enter to submit)
     /// Returns Ok(Some(text)) if Enter pressed, Ok(None) if ESC pressed
-    async fn read_user_input_with_esc(timeout: Duration) -> Result<Option<String>> {
-        let timeout_for_renderer = timeout;
-        tokio::task::spawn_blocking(move || -> Result<Option<String>> {
-            enable_raw_mode().context("Failed to enable raw mode")?;
-            let _guard = RawModeGuard;
+    fn read_user_input_with_esc(
+        timeout: Duration,
+        cancelled: Arc<AtomicBool>,
+    ) -> Result<Option<String>> {
+        enable_raw_mode().context("Failed to enable raw mode")?;
+        let _guard = RawModeGuard;
 
-            let mut buffer = String::new();
-            let mut countdown = CountdownRenderer::new(timeout_for_renderer);
+        let mut buffer = String::new();
+        let mut countdown = CountdownRenderer::new(timeout);
+        let mut countdown_enabled = true;
 
-            println!("\x1B[s");
-            io::stdout().flush()?;
+        println!("\x1B[s");
+        io::stdout().flush()?;
 
-            loop {
-                if event::poll(Duration::from_millis(100))? {
-                    if let Event::Key(key_event) = event::read()? {
-                        if key_event.kind == KeyEventKind::Press {
-                            match key_event.code {
-                                KeyCode::Esc => {
-                                    print!("\r\x1B[2K\x1B[u");
-                                    io::stdout().flush().ok();
-                                    println!();
-                                    return Ok(None);
-                                }
-                                KeyCode::Enter => {
-                                    print!("\r\x1B[2K\x1B[u");
-                                    io::stdout().flush().ok();
-                                    println!();
-                                    let answer = buffer.trim().to_string();
-                                    return Ok(Some(answer));
-                                }
-                                KeyCode::Char(c) => {
-                                    buffer.push(c);
-                                    print!("\x1B[u{}\x1B[s\x1B[B\r", c);
-                                    io::stdout().flush()?;
-                                }
-                                KeyCode::Backspace if !buffer.is_empty() => {
-                                    buffer.pop();
-                                    print!("\x1B[u\x08 \x08\x1B[s\x1B[B\r");
-                                    io::stdout().flush()?;
-                                }
-                                _ => {}
+        loop {
+            if cancelled.load(Ordering::Relaxed) {
+                print!("\r\x1B[2K\x1B[u");
+                io::stdout().flush().ok();
+                println!();
+                return Ok(None);
+            }
+
+            if countdown.remaining_secs() == 0 {
+                print!("{}", countdown.render_final());
+                io::stdout().flush().ok();
+                return Err(anyhow::anyhow!("Question timed out"));
+            }
+
+            if event::poll(Duration::from_millis(100))? {
+                if let Event::Key(key_event) = event::read()? {
+                    if key_event.kind == KeyEventKind::Press {
+                        match key_event.code {
+                            KeyCode::Esc => {
+                                print!("\r\x1B[2K\x1B[u");
+                                io::stdout().flush().ok();
+                                println!();
+                                return Ok(None);
                             }
+                            KeyCode::Enter => {
+                                print!("\r\x1B[2K\x1B[u");
+                                io::stdout().flush().ok();
+                                println!();
+                                let answer = buffer.trim().to_string();
+                                return Ok(Some(answer));
+                            }
+                            KeyCode::Char(c) => {
+                                buffer.push(c);
+                                print!("\x1B[u{}\x1B[s\x1B[B\r", c);
+                                io::stdout().flush()?;
+                            }
+                            KeyCode::Backspace if !buffer.is_empty() => {
+                                buffer.pop();
+                                print!("\x1B[u\x08 \x08\x1B[s\x1B[B\r");
+                                io::stdout().flush()?;
+                            }
+                            _ => {}
                         }
                     }
-                } else if let Some(update) = countdown.render_update() {
+                }
+            } else if countdown_enabled {
+                if let Some(update) = countdown.render_update() {
                     let mut stdout = io::stdout();
                     if stdout.write_all(update.as_bytes()).is_ok() {
                         let _ = stdout.flush();
+                    } else {
+                        countdown_enabled = false;
                     }
                 }
             }
-        })
-        .await
-        .context("Failed to spawn blocking task")?
-        .context("Failed to read input")
+        }
     }
 
     /// Read authorization response with ESC support (ESC to skip, Enter to submit)
     /// Returns Ok(Some(ResponseType)) if Enter pressed, Ok(None) if ESC pressed
-    async fn read_authorization_with_esc(timeout: Duration) -> Result<Option<ResponseType>> {
-        let timeout_for_renderer = timeout;
-        let result = tokio::task::spawn_blocking(move || -> Result<Option<ResponseType>> {
-            enable_raw_mode().context("Failed to enable raw mode")?;
-            let _guard = RawModeGuard;
+    fn read_authorization_with_esc(
+        timeout: Duration,
+        cancelled: Arc<AtomicBool>,
+    ) -> Result<Option<ResponseType>> {
+        enable_raw_mode().context("Failed to enable raw mode")?;
+        let _guard = RawModeGuard;
 
-            let mut buffer = String::new();
-            let mut countdown = CountdownRenderer::new(timeout_for_renderer);
+        let mut buffer = String::new();
+        let mut countdown = CountdownRenderer::new(timeout);
+        let mut countdown_enabled = true;
 
-            println!("\x1B[s");
-            io::stdout().flush()?;
+        println!("\x1B[s");
+        io::stdout().flush()?;
 
-            loop {
-                if event::poll(Duration::from_millis(100))? {
-                    if let Event::Key(key_event) = event::read()? {
-                        if key_event.kind == KeyEventKind::Press {
-                            match key_event.code {
-                                KeyCode::Esc => {
-                                    print!("\r\x1B[2K\x1B[u");
-                                    io::stdout().flush().ok();
-                                    println!();
-                                    return Ok(None);
-                                }
-                                KeyCode::Enter => {
-                                    print!("\r\x1B[2K\x1B[u");
-                                    io::stdout().flush().ok();
-                                    println!();
+        loop {
+            if cancelled.load(Ordering::Relaxed) {
+                print!("\r\x1B[2K\x1B[u");
+                io::stdout().flush().ok();
+                println!();
+                return Ok(None);
+            }
 
-                                    let normalized = buffer.trim().to_lowercase();
-                                    let decision = match normalized.as_str() {
-                                        "y" | "yes" | "authorized" | "approve" | "ok" => {
-                                            ResponseType::AuthorizationApproved
-                                        }
-                                        "n" | "no" | "denied" | "deny" | "reject" | "" => {
-                                            ResponseType::AuthorizationDenied
-                                        }
-                                        _ => {
-                                            eprintln!("Invalid input '{}'. Expected Y/n. Defaulting to DENIED.", buffer.trim());
-                                            ResponseType::AuthorizationDenied
-                                        }
-                                    };
-                                    return Ok(Some(decision));
-                                }
-                                KeyCode::Char(c) => {
-                                    buffer.push(c);
-                                    print!("\x1B[u{}\x1B[s\x1B[B\r", c);
-                                    io::stdout().flush()?;
-                                }
-                                KeyCode::Backspace if !buffer.is_empty() => {
-                                    buffer.pop();
-                                    print!("\x1B[u\x08 \x08\x1B[s\x1B[B\r");
-                                    io::stdout().flush()?;
-                                }
-                                _ => {}
+            if countdown.remaining_secs() == 0 {
+                print!("{}", countdown.render_final());
+                io::stdout().flush().ok();
+                return Err(anyhow::anyhow!("Authorization timed out"));
+            }
+
+            if event::poll(Duration::from_millis(100))? {
+                if let Event::Key(key_event) = event::read()? {
+                    if key_event.kind == KeyEventKind::Press {
+                        match key_event.code {
+                            KeyCode::Esc => {
+                                print!("\r\x1B[2K\x1B[u");
+                                io::stdout().flush().ok();
+                                println!();
+                                return Ok(None);
                             }
+                            KeyCode::Enter => {
+                                print!("\r\x1B[2K\x1B[u");
+                                io::stdout().flush().ok();
+                                println!();
+
+                                let normalized = buffer.trim().to_lowercase();
+                                let decision = match normalized.as_str() {
+                                    "y" | "yes" | "authorized" | "approve" | "ok" => {
+                                        ResponseType::AuthorizationApproved
+                                    }
+                                    "n" | "no" | "denied" | "deny" | "reject" | "" => {
+                                        ResponseType::AuthorizationDenied
+                                    }
+                                    _ => {
+                                        eprintln!(
+                                            "Invalid input '{}'. Expected Y/n. Defaulting to DENIED.",
+                                            buffer.trim()
+                                        );
+                                        ResponseType::AuthorizationDenied
+                                    }
+                                };
+                                return Ok(Some(decision));
+                            }
+                            KeyCode::Char(c) => {
+                                buffer.push(c);
+                                print!("\x1B[u{}\x1B[s\x1B[B\r", c);
+                                io::stdout().flush()?;
+                            }
+                            KeyCode::Backspace if !buffer.is_empty() => {
+                                buffer.pop();
+                                print!("\x1B[u\x08 \x08\x1B[s\x1B[B\r");
+                                io::stdout().flush()?;
+                            }
+                            _ => {}
                         }
                     }
-                } else if let Some(update) = countdown.render_update() {
+                }
+            } else if countdown_enabled {
+                if let Some(update) = countdown.render_update() {
                     let mut stdout = io::stdout();
                     if stdout.write_all(update.as_bytes()).is_ok() {
                         let _ = stdout.flush();
+                    } else {
+                        countdown_enabled = false;
                     }
                 }
             }
-        })
-        .await
-        .context("Failed to spawn blocking task")?
-        .context("Failed to read input")?;
-
-        Ok(result)
+        }
     }
 }
 

--- a/ailoop-core/src/server/core.rs
+++ b/ailoop-core/src/server/core.rs
@@ -980,16 +980,24 @@ impl AiloopServer {
             let mut buffer = String::new();
             let mut countdown = CountdownRenderer::new(timeout_for_renderer);
 
+            println!("\x1B[s");
+            io::stdout().flush()?;
+
             loop {
                 if event::poll(Duration::from_millis(100))? {
                     if let Event::Key(key_event) = event::read()? {
                         if key_event.kind == KeyEventKind::Press {
                             match key_event.code {
                                 KeyCode::Esc => {
+                                    print!("\r\x1B[2K\x1B[u");
+                                    io::stdout().flush().ok();
                                     disable_raw_mode().ok();
+                                    println!();
                                     return Ok(None);
                                 }
                                 KeyCode::Enter => {
+                                    print!("\r\x1B[2K\x1B[u");
+                                    io::stdout().flush().ok();
                                     disable_raw_mode().ok();
                                     println!();
                                     let answer = buffer.trim().to_string();
@@ -997,12 +1005,12 @@ impl AiloopServer {
                                 }
                                 KeyCode::Char(c) => {
                                     buffer.push(c);
-                                    print!("{}", c);
+                                    print!("\x1B[u{}\x1B[s\x1B[B\r", c);
                                     io::stdout().flush()?;
                                 }
                                 KeyCode::Backspace if !buffer.is_empty() => {
                                     buffer.pop();
-                                    print!("\x08 \x08");
+                                    print!("\x1B[u\x08 \x08\x1B[s\x1B[B\r");
                                     io::stdout().flush()?;
                                 }
                                 _ => {}
@@ -1032,16 +1040,24 @@ impl AiloopServer {
             let mut buffer = String::new();
             let mut countdown = CountdownRenderer::new(timeout_for_renderer);
 
+            println!("\x1B[s");
+            io::stdout().flush()?;
+
             loop {
                 if event::poll(Duration::from_millis(100))? {
                     if let Event::Key(key_event) = event::read()? {
                         if key_event.kind == KeyEventKind::Press {
                             match key_event.code {
                                 KeyCode::Esc => {
+                                    print!("\r\x1B[2K\x1B[u");
+                                    io::stdout().flush().ok();
                                     disable_raw_mode().ok();
+                                    println!();
                                     return Ok(None);
                                 }
                                 KeyCode::Enter => {
+                                    print!("\r\x1B[2K\x1B[u");
+                                    io::stdout().flush().ok();
                                     disable_raw_mode().ok();
                                     println!();
 
@@ -1062,12 +1078,12 @@ impl AiloopServer {
                                 }
                                 KeyCode::Char(c) => {
                                     buffer.push(c);
-                                    print!("{}", c);
+                                    print!("\x1B[u{}\x1B[s\x1B[B\r", c);
                                     io::stdout().flush()?;
                                 }
                                 KeyCode::Backspace if !buffer.is_empty() => {
                                     buffer.pop();
-                                    print!("\x08 \x08");
+                                    print!("\x1B[u\x08 \x08\x1B[s\x1B[B\r");
                                     io::stdout().flush()?;
                                 }
                                 _ => {}

--- a/ailoop-core/src/server/core.rs
+++ b/ailoop-core/src/server/core.rs
@@ -3,6 +3,7 @@
 use crate::channel::ChannelIsolation;
 use crate::models::{Configuration, Message, MessageContent, ResponseType};
 use crate::server::providers::{PendingPromptRegistry, PromptType, ReplySource};
+use crate::terminal::countdown::CountdownRenderer;
 use anyhow::{Context, Result};
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind},
@@ -471,7 +472,7 @@ impl AiloopServer {
 
         let (answer_text, response_type, selected_index) = if use_terminal {
             tokio::select! {
-                result = Self::read_user_input_with_esc() => {
+                result = Self::read_user_input_with_esc(timeout_duration) => {
                     match result {
                         Ok(Some(text)) => {
                             let (final_answer, index) = Self::process_answer(&text, &choices);
@@ -669,7 +670,7 @@ impl AiloopServer {
 
         let decision = if use_terminal {
             tokio::select! {
-                result = Self::read_authorization_with_esc() => {
+                result = Self::read_authorization_with_esc(timeout_duration) => {
                     match result {
                         Ok(Some(response_type)) => {
                             let content = MessageContent::Response {
@@ -819,7 +820,7 @@ impl AiloopServer {
 
         let decision = if use_terminal {
             tokio::select! {
-                result = Self::read_authorization_with_esc() => {
+                result = Self::read_authorization_with_esc(default_timeout) => {
                     match result {
                         Ok(Some(response_type)) => {
                             let content = MessageContent::Response {
@@ -971,12 +972,13 @@ impl AiloopServer {
 
     /// Read user input with ESC support (ESC to skip, Enter to submit)
     /// Returns Ok(Some(text)) if Enter pressed, Ok(None) if ESC pressed
-    async fn read_user_input_with_esc() -> Result<Option<String>> {
-        tokio::task::spawn_blocking(|| -> Result<Option<String>> {
-            // Enable raw mode to read characters
+    async fn read_user_input_with_esc(timeout: Duration) -> Result<Option<String>> {
+        let timeout_for_renderer = timeout;
+        tokio::task::spawn_blocking(move || -> Result<Option<String>> {
             enable_raw_mode().context("Failed to enable raw mode")?;
 
             let mut buffer = String::new();
+            let mut countdown = CountdownRenderer::new(timeout_for_renderer);
 
             loop {
                 if event::poll(Duration::from_millis(100))? {
@@ -984,34 +986,33 @@ impl AiloopServer {
                         if key_event.kind == KeyEventKind::Press {
                             match key_event.code {
                                 KeyCode::Esc => {
-                                    // ESC pressed - skip question
                                     disable_raw_mode().ok();
                                     return Ok(None);
                                 }
                                 KeyCode::Enter => {
-                                    // Enter pressed - submit answer (even if empty)
                                     disable_raw_mode().ok();
-                                    println!(); // New line after Enter
-                                                // Always return the buffer content, even if empty
-                                                // Empty string is a valid answer
+                                    println!();
                                     let answer = buffer.trim().to_string();
                                     return Ok(Some(answer));
                                 }
                                 KeyCode::Char(c) => {
-                                    // Regular character
                                     buffer.push(c);
                                     print!("{}", c);
                                     io::stdout().flush()?;
                                 }
                                 KeyCode::Backspace if !buffer.is_empty() => {
-                                    // Backspace
                                     buffer.pop();
-                                    print!("\x08 \x08"); // Backspace, space, backspace
+                                    print!("\x08 \x08");
                                     io::stdout().flush()?;
                                 }
                                 _ => {}
                             }
                         }
+                    }
+                } else if let Some(update) = countdown.render_update() {
+                    let mut stdout = io::stdout();
+                    if stdout.write_all(update.as_bytes()).is_ok() {
+                        let _ = stdout.flush();
                     }
                 }
             }
@@ -1023,12 +1024,13 @@ impl AiloopServer {
 
     /// Read authorization response with ESC support (ESC to skip, Enter to submit)
     /// Returns Ok(Some(ResponseType)) if Enter pressed, Ok(None) if ESC pressed
-    async fn read_authorization_with_esc() -> Result<Option<ResponseType>> {
-        let result = tokio::task::spawn_blocking(|| -> Result<Option<ResponseType>> {
-            // Enable raw mode to read characters
+    async fn read_authorization_with_esc(timeout: Duration) -> Result<Option<ResponseType>> {
+        let timeout_for_renderer = timeout;
+        let result = tokio::task::spawn_blocking(move || -> Result<Option<ResponseType>> {
             enable_raw_mode().context("Failed to enable raw mode")?;
 
             let mut buffer = String::new();
+            let mut countdown = CountdownRenderer::new(timeout_for_renderer);
 
             loop {
                 if event::poll(Duration::from_millis(100))? {
@@ -1036,14 +1038,12 @@ impl AiloopServer {
                         if key_event.kind == KeyEventKind::Press {
                             match key_event.code {
                                 KeyCode::Esc => {
-                                    // ESC pressed - skip
                                     disable_raw_mode().ok();
                                     return Ok(None);
                                 }
                                 KeyCode::Enter => {
-                                    // Enter pressed - parse and return decision
                                     disable_raw_mode().ok();
-                                    println!(); // New line after Enter
+                                    println!();
 
                                     let normalized = buffer.trim().to_lowercase();
                                     let decision = match normalized.as_str() {
@@ -1051,11 +1051,9 @@ impl AiloopServer {
                                             ResponseType::AuthorizationApproved
                                         }
                                         "n" | "no" | "denied" | "deny" | "reject" | "" => {
-                                            // Empty input (just Enter) defaults to denied for safety
                                             ResponseType::AuthorizationDenied
                                         }
                                         _ => {
-                                            // Invalid input - default to denied (safer default)
                                             eprintln!("Invalid input '{}'. Expected Y/n. Defaulting to DENIED.", buffer.trim());
                                             ResponseType::AuthorizationDenied
                                         }
@@ -1063,20 +1061,23 @@ impl AiloopServer {
                                     return Ok(Some(decision));
                                 }
                                 KeyCode::Char(c) => {
-                                    // Regular character
                                     buffer.push(c);
                                     print!("{}", c);
                                     io::stdout().flush()?;
                                 }
                                 KeyCode::Backspace if !buffer.is_empty() => {
-                                    // Backspace
                                     buffer.pop();
-                                    print!("\x08 \x08"); // Backspace, space, backspace
+                                    print!("\x08 \x08");
                                     io::stdout().flush()?;
                                 }
                                 _ => {}
                             }
                         }
+                    }
+                } else if let Some(update) = countdown.render_update() {
+                    let mut stdout = io::stdout();
+                    if stdout.write_all(update.as_bytes()).is_ok() {
+                        let _ = stdout.flush();
                     }
                 }
             }

--- a/ailoop-core/src/server/core.rs
+++ b/ailoop-core/src/server/core.rs
@@ -976,6 +976,7 @@ impl AiloopServer {
         let timeout_for_renderer = timeout;
         tokio::task::spawn_blocking(move || -> Result<Option<String>> {
             enable_raw_mode().context("Failed to enable raw mode")?;
+            let _guard = RawModeGuard;
 
             let mut buffer = String::new();
             let mut countdown = CountdownRenderer::new(timeout_for_renderer);
@@ -991,14 +992,12 @@ impl AiloopServer {
                                 KeyCode::Esc => {
                                     print!("\r\x1B[2K\x1B[u");
                                     io::stdout().flush().ok();
-                                    disable_raw_mode().ok();
                                     println!();
                                     return Ok(None);
                                 }
                                 KeyCode::Enter => {
                                     print!("\r\x1B[2K\x1B[u");
                                     io::stdout().flush().ok();
-                                    disable_raw_mode().ok();
                                     println!();
                                     let answer = buffer.trim().to_string();
                                     return Ok(Some(answer));
@@ -1036,6 +1035,7 @@ impl AiloopServer {
         let timeout_for_renderer = timeout;
         let result = tokio::task::spawn_blocking(move || -> Result<Option<ResponseType>> {
             enable_raw_mode().context("Failed to enable raw mode")?;
+            let _guard = RawModeGuard;
 
             let mut buffer = String::new();
             let mut countdown = CountdownRenderer::new(timeout_for_renderer);
@@ -1051,14 +1051,12 @@ impl AiloopServer {
                                 KeyCode::Esc => {
                                     print!("\r\x1B[2K\x1B[u");
                                     io::stdout().flush().ok();
-                                    disable_raw_mode().ok();
                                     println!();
                                     return Ok(None);
                                 }
                                 KeyCode::Enter => {
                                     print!("\r\x1B[2K\x1B[u");
                                     io::stdout().flush().ok();
-                                    disable_raw_mode().ok();
                                     println!();
 
                                     let normalized = buffer.trim().to_lowercase();
@@ -1103,5 +1101,13 @@ impl AiloopServer {
         .context("Failed to read input")?;
 
         Ok(result)
+    }
+}
+
+struct RawModeGuard;
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        disable_raw_mode().ok();
     }
 }

--- a/ailoop-core/src/terminal/countdown.rs
+++ b/ailoop-core/src/terminal/countdown.rs
@@ -1,0 +1,120 @@
+use std::time::{Duration, Instant};
+
+pub struct CountdownRenderer {
+    timeout: Duration,
+    start: Instant,
+    last_rendered_secs: Option<u64>,
+}
+
+pub enum InputResult {
+    Submitted(String),
+    Cancelled,
+    Timeout,
+}
+
+impl CountdownRenderer {
+    pub fn new(timeout: Duration) -> Self {
+        Self {
+            timeout,
+            start: Instant::now(),
+            last_rendered_secs: None,
+        }
+    }
+
+    pub fn remaining_secs(&self) -> u64 {
+        let elapsed = self.start.elapsed();
+        self.timeout
+            .checked_sub(elapsed)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+
+    pub fn needs_update(&self) -> bool {
+        let current = self.remaining_secs();
+        match self.last_rendered_secs {
+            Some(last) => current != last,
+            None => true,
+        }
+    }
+
+    pub fn render_update(&mut self) -> Option<String> {
+        if self.needs_update() {
+            let remaining = self.remaining_secs();
+            self.last_rendered_secs = Some(remaining);
+            Some(format!("\r\x1B[2KTimeout: {} seconds", remaining))
+        } else {
+            None
+        }
+    }
+
+    pub fn render_final(&self) -> String {
+        "\r\x1B[2KTimeout: 0 seconds\n".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_renderer(timeout: Duration, elapsed: Duration) -> CountdownRenderer {
+        let mut renderer = CountdownRenderer::new(timeout);
+        renderer.start = Instant::now() - elapsed;
+        renderer
+    }
+
+    #[test]
+    fn test_initial_needs_update() {
+        let renderer = make_renderer(Duration::from_secs(10), Duration::ZERO);
+        assert!(renderer.needs_update());
+    }
+
+    #[test]
+    fn test_initial_render_update() {
+        let mut renderer = make_renderer(Duration::from_secs(100), Duration::ZERO);
+        let result = renderer.render_update();
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("Timeout:"));
+        assert!(text.contains("seconds"));
+        assert!(text.starts_with('\r'));
+        assert!(text.contains('\x1B'));
+        let remaining = renderer.remaining_secs();
+        assert!((99..=100).contains(&remaining));
+    }
+
+    #[test]
+    fn test_no_update_when_second_unchanged() {
+        let mut renderer = make_renderer(Duration::from_secs(100), Duration::ZERO);
+        let _ = renderer.render_update();
+        assert!(!renderer.needs_update());
+        assert!(renderer.render_update().is_none());
+    }
+
+    #[test]
+    fn test_remaining_secs_at_zero() {
+        let renderer = make_renderer(Duration::from_secs(0), Duration::from_secs(1));
+        assert_eq!(renderer.remaining_secs(), 0);
+    }
+
+    #[test]
+    fn test_render_final() {
+        let renderer = CountdownRenderer::new(Duration::from_secs(5));
+        let final_text = renderer.render_final();
+        assert!(final_text.contains("Timeout: 0 seconds"));
+        assert!(final_text.ends_with('\n'));
+    }
+
+    #[test]
+    fn test_render_update_tracks_last_rendered() {
+        let mut renderer = make_renderer(Duration::from_secs(100), Duration::ZERO);
+        let _ = renderer.render_update();
+        let tracked = renderer.last_rendered_secs.unwrap();
+        assert!((99..=100).contains(&tracked));
+    }
+
+    #[test]
+    fn test_remaining_secs_decreases() {
+        let renderer = make_renderer(Duration::from_secs(10), Duration::from_millis(2500));
+        assert_eq!(renderer.remaining_secs(), 7);
+    }
+}

--- a/ailoop-core/src/terminal/mod.rs
+++ b/ailoop-core/src/terminal/mod.rs
@@ -1,0 +1,1 @@
+pub mod countdown;

--- a/ailoop-py/uv.lock
+++ b/ailoop-py/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ailoop-py"
-version = "0.1.29"
+version = "0.1.30"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/test-results.json
+++ b/test-results.json
@@ -1,0 +1,9 @@
+{
+  "status": "passed",
+  "timestamp": "2026-04-25T20:49:52Z",
+  "exit_code": 0,
+
+  "checks": { "version": true, "rust_fmt": true, "rust_clippy": true, "rust_tests": true, "python": true, "typescript": true },
+
+  "test_statistics": { "total": 1, "passed": 1, "failed": 0, "skipped": 0, "passing_percentage": 100 }
+}

--- a/test-results.md
+++ b/test-results.md
@@ -1,0 +1,28 @@
+# AILOOP Test Results Report
+Generated: 2026-04-25T20:49:52Z
+Command: ./scripts/run-tests.sh
+
+## Overall Status
+PASSED - All tests completed successfully
+
+## Checks (match CI)
+- Version: PASSED
+- Rust fmt: PASSED
+- Rust clippy: PASSED
+- Rust tests: PASSED
+- Python: PASSED
+- TypeScript: PASSED
+
+## Test Statistics
+- Total Tests: 1
+- Passed: 1
+- Failed: 0
+- Skipped: 0
+- Passing Rate: 100%
+
+## Progress Visualization
+[##############################] 100% (1/1)
+
+## Files
+- Markdown Report: test-results.md
+- JSON results: test-results.json


### PR DESCRIPTION
## Summary
- fix countdown prompt readers so direct CLI mode cancels and joins the blocking terminal task before returning on Ctrl+C
- fix server terminal prompts to cancel and join the raw-mode reader when provider replies, prompt timeouts, or Ctrl+C win the race
- render the final `Timeout: 0 seconds` state before timed prompts resolve and stop repainting if countdown writes fail

## Why
Issue #15 required the timeout countdown prompts to leave the terminal in a clean state on every exit path. The prior implementation could abandon a raw-mode blocking task when another `select!` branch won, leaving the terminal reader alive after the prompt had already resolved.

## Impact
- interactive `ask` and `authorize` prompts now shut down cleanly when cancelled externally
- server-mode terminal prompts no longer leak raw-mode readers after provider replies or timeouts
- countdown behavior is closer to the spec because `0` is rendered before timeout resolution

## Validation
- `cargo fmt`
- `cargo check`
- `cargo test -p ailoop-core countdown -- --nocapture`
- `cargo test -p ailoop-cli parse_authorization_response -- --nocapture`
- repo pre-push suite (`git push`) passed
