### PR TITLE
feat: add --web flag to serve embedded browser UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,30 @@ Defaults:
 - WebSocket listener: `ws://127.0.0.1:8080`
 - HTTP API and web UI: `http://127.0.0.1:8081`
 
+### Set the server URL once
+
+Instead of passing `--server` on every command, export `AILOOP_SERVER`:
+
+```bash
+export AILOOP_SERVER=http://127.0.0.1:8080
+```
+
+Add it to `~/.bashrc` (or `~/.zshrc`) to make it permanent:
+
+```bash
+echo 'export AILOOP_SERVER=http://127.0.0.1:8080' >> ~/.bashrc
+source ~/.bashrc
+```
+
 ### Send messages from another terminal
 
 ```bash
-ailoop ask "Can we deploy now?" --server http://127.0.0.1:8080
-ailoop authorize "Deploy version 1.2.3?" --server http://127.0.0.1:8080 --default no
-ailoop say "Build finished" --priority normal --server http://127.0.0.1:8080
+ailoop ask "Can we deploy now?"
+ailoop authorize "Deploy version 1.2.3?" --default no
+ailoop say "Build finished" --priority normal
 ```
+
+Pass `--server` explicitly to override `AILOOP_SERVER` for a single command.
 
 ### Forward agent output
 

--- a/ailoop-cli/src/cli/handlers.rs
+++ b/ailoop-cli/src/cli/handlers.rs
@@ -748,7 +748,7 @@ pub async fn handle_say(
 }
 
 /// Handle the 'serve' command
-pub async fn handle_serve(host: String, port: u16, channel: String) -> Result<()> {
+pub async fn handle_serve(host: String, port: u16, channel: String, web: bool) -> Result<()> {
     use ailoop_core::models::Configuration;
     use std::path::PathBuf;
 
@@ -761,7 +761,9 @@ pub async fn handle_serve(host: String, port: u16, channel: String) -> Result<()
         Configuration::default_config_path().unwrap_or_else(|_| PathBuf::from("config.toml"));
     let config = Configuration::load_from_file(&config_path).unwrap_or_default();
 
-    let server = ailoop_core::server::AiloopServer::new(host, port, channel).with_config(config);
+    let server = ailoop_core::server::AiloopServer::new(host, port, channel)
+        .with_config(config)
+        .with_web(web);
     server.start().await
 }
 

--- a/ailoop-cli/src/main.rs
+++ b/ailoop-cli/src/main.rs
@@ -135,6 +135,10 @@ enum Commands {
         /// Default channel name
         #[arg(short, long, default_value = "public")]
         channel: String,
+
+        /// Enable the embedded web UI on the HTTP API port (port+1)
+        #[arg(long)]
+        web: bool,
     },
 
     /// Configure ailoop settings interactively
@@ -267,8 +271,9 @@ async fn main() -> Result<()> {
             host,
             port,
             channel,
+            web,
         } => {
-            handlers::handle_serve(host, port, channel).await?;
+            handlers::handle_serve(host, port, channel, web).await?;
         }
         Commands::Config { init, config_file } => {
             if init {

--- a/ailoop-core/assets/ailoop-ui.html
+++ b/ailoop-core/assets/ailoop-ui.html
@@ -1,0 +1,1122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ailoop</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin="anonymous"></script>
+
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --font: 'JetBrains Mono', monospace;
+  --bg: #0a0a0f;
+  --bg1: #0f0f17;
+  --bg2: #14141f;
+  --bg3: #1a1a28;
+  --border: #252535;
+  --border2: #2e2e46;
+  --text: #c8c8e0;
+  --text-dim: #5a5a7a;
+  --text-bright: #e8e8f8;
+  --accent: #7c3aed;
+  --accent-bright: #9d5cf5;
+  --accent-dim: #3d1c7a;
+  --ask: #2563eb;
+  --ask-dim: #1e3a8a;
+  --auth-yes: #16a34a;
+  --auth-no: #dc2626;
+  --say: #7c3aed;
+  --forward: #0891b2;
+  --forward-dim: #0c4a6e;
+  --warn: #d97706;
+  --urgent: #ef4444;
+  --scrollbar: #1e1e30;
+  --radius: 3px;
+}
+
+html, body { height: 100%; background: var(--bg); color: var(--text); font-family: var(--font); font-size: 13px; line-height: 1.5; overflow: hidden; }
+#root { height: 100%; display: flex; flex-direction: column; }
+
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: var(--bg); }
+::-webkit-scrollbar-thumb { background: var(--border2); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--accent-dim); }
+
+.topbar {
+  display: flex; align-items: center; gap: 12px;
+  padding: 0 16px;
+  height: 44px;
+  background: var(--bg1);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.topbar-logo {
+  font-size: 14px; font-weight: 700; letter-spacing: -0.02em;
+  color: var(--accent-bright);
+  display: flex; align-items: center; gap: 8px;
+}
+.topbar-logo svg { width: 16px; height: 16px; }
+.topbar-sep { width: 1px; height: 20px; background: var(--border); flex-shrink: 0; }
+.conn-form { display: flex; align-items: center; gap: 8px; flex: 1; }
+.conn-input {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-bright);
+  font-family: var(--font);
+  font-size: 12px;
+  padding: 5px 10px;
+  width: 260px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.conn-input:focus { border-color: var(--accent); }
+.conn-input::placeholder { color: var(--text-dim); }
+.btn {
+  font-family: var(--font);
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  padding: 5px 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.btn-connect { background: var(--accent); color: #fff; border-color: var(--accent-bright); }
+.btn-connect:hover { background: var(--accent-bright); }
+.btn-disconnect { background: transparent; color: var(--text-dim); border-color: var(--border2); }
+.btn-disconnect:hover { color: var(--text); border-color: var(--text-dim); }
+
+.status-indicator {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.status-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--border2);
+  transition: background 0.3s;
+}
+.status-dot.connected { background: var(--auth-yes); box-shadow: 0 0 6px var(--auth-yes); }
+.status-dot.connecting { background: var(--warn); animation: pulse 1s infinite; }
+.status-dot.error { background: var(--urgent); }
+
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+
+.layout { display: flex; flex: 1; overflow: hidden; min-height: 0; }
+
+.sidebar {
+  width: 180px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg1);
+  overflow: hidden;
+}
+.sidebar-section { padding: 10px 0; border-bottom: 1px solid var(--border); }
+.sidebar-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+  padding: 0 14px 6px;
+  text-transform: uppercase;
+}
+.channel-item {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 5px 14px;
+  cursor: pointer;
+  transition: background 0.1s;
+  gap: 6px;
+}
+.channel-item:hover { background: var(--bg2); }
+.channel-item.active { background: var(--accent-dim); }
+.channel-item.active .ch-name { color: var(--accent-bright); }
+.ch-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border2); flex-shrink: 0; }
+.ch-dot.active { background: var(--accent-bright); }
+.ch-name { font-size: 12px; color: var(--text); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ch-count {
+  font-size: 10px;
+  color: var(--text-dim);
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0 5px;
+  min-width: 20px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.stats-grid { padding: 10px 14px; display: flex; flex-direction: column; gap: 6px; }
+.stat-row { display: flex; justify-content: space-between; align-items: center; }
+.stat-label { font-size: 11px; color: var(--text-dim); }
+.stat-val { font-size: 11px; font-weight: 600; }
+.stat-val.ask { color: #60a5fa; }
+.stat-val.auth { color: #4ade80; }
+.stat-val.say { color: var(--accent-bright); }
+.stat-val.forward { color: #38bdf8; }
+
+.feed-area { flex: 1; display: flex; flex-direction: column; min-width: 0; overflow: hidden; }
+.feed-toolbar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  background: var(--bg1);
+}
+.filter-btn {
+  font-family: var(--font);
+  font-size: 11px;
+  font-weight: 500;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-dim);
+  padding: 3px 10px;
+  cursor: pointer;
+  transition: all 0.12s;
+}
+.filter-btn:hover { color: var(--text); border-color: var(--border2); }
+.filter-btn.active-ask { background: var(--ask-dim); color: #93c5fd; border-color: var(--ask); }
+.filter-btn.active-authorize { background: #14532d; color: #86efac; border-color: var(--auth-yes); }
+.filter-btn.active-say { background: var(--accent-dim); color: var(--accent-bright); border-color: var(--accent); }
+.filter-btn.active-events { background: var(--forward-dim); color: #38bdf8; border-color: var(--forward); }
+.filter-btn.active-all { background: var(--bg3); color: var(--text-bright); border-color: var(--border2); }
+.feed-toolbar-right { margin-left: auto; display: flex; gap: 6px; align-items: center; }
+.btn-clear { font-family: var(--font); font-size: 11px; background: transparent; border: none; color: var(--text-dim); cursor: pointer; padding: 3px 8px; }
+.btn-clear:hover { color: var(--text); }
+.scroll-btn { font-family: var(--font); font-size: 11px; background: transparent; border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-dim); cursor: pointer; padding: 3px 8px; }
+.scroll-btn:hover { color: var(--text); border-color: var(--border2); }
+
+.feed { flex: 1; overflow-y: auto; padding: 10px 0; }
+.feed-empty {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  height: 100%; gap: 10px; color: var(--text-dim);
+}
+.feed-empty-icon { font-size: 28px; opacity: 0.3; }
+.feed-empty-text { font-size: 12px; opacity: 0.5; text-align: center; line-height: 1.8; white-space: pre-line; }
+
+.event-card {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.1s;
+  position: relative;
+  animation: slideIn 0.18s ease-out;
+}
+@keyframes slideIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
+.event-card:hover { background: var(--bg2); }
+.event-card:last-child { border-bottom: none; }
+
+.event-stripe { width: 3px; flex-shrink: 0; }
+.stripe-ask { background: #3b82f6; }
+.stripe-authorize { background: var(--auth-yes); }
+.stripe-say { background: var(--accent); }
+.stripe-events { background: var(--forward); }
+.stripe-error { background: var(--urgent); }
+.stripe-unknown { background: var(--text-dim); }
+
+.event-body { flex: 1; padding: 10px 14px; min-width: 0; }
+.event-meta { display: flex; align-items: center; gap: 8px; margin-bottom: 5px; flex-wrap: wrap; }
+.event-type {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.08em;
+  padding: 1px 7px; border-radius: 2px;
+  text-transform: uppercase;
+}
+.type-ask { background: var(--ask-dim); color: #93c5fd; border: 1px solid var(--ask); }
+.type-authorize { background: #14532d; color: #86efac; border: 1px solid #166534; }
+.type-say { background: var(--accent-dim); color: #c084fc; border: 1px solid var(--accent); }
+.type-events { background: var(--forward-dim); color: #38bdf8; border: 1px solid #0e7490; }
+.type-error { background: #450a0a; color: #fca5a5; border: 1px solid #991b1b; }
+
+.event-channel { font-size: 10px; color: var(--text-dim); }
+.event-channel span { color: var(--text); }
+.event-ts { font-size: 10px; color: var(--text-dim); margin-left: auto; flex-shrink: 0; }
+
+.event-msg { font-size: 12px; color: var(--text-bright); line-height: 1.5; word-break: break-word; }
+
+.forward-content {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+  margin-top: 6px;
+  font-size: 11px;
+  color: #94a3b8;
+  max-height: 120px;
+  overflow-y: auto;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.priority {
+  font-size: 10px; font-weight: 600;
+  padding: 1px 6px; border-radius: 2px;
+}
+.priority-low { color: var(--text-dim); }
+.priority-normal { color: var(--text-dim); }
+.priority-high { color: var(--warn); background: #451a03; border: 1px solid #78350f; }
+.priority-urgent { color: var(--urgent); background: #450a0a; border: 1px solid #991b1b; }
+
+.btn-respond {
+  font-family: var(--font);
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: var(--radius);
+  padding: 6px 14px;
+  cursor: pointer;
+  transition: all 0.12s;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.btn-send { background: var(--ask); color: #fff; border-color: #3b82f6; }
+.btn-send:hover { background: #3b82f6; }
+.btn-approve { background: var(--auth-yes); color: #fff; border-color: #22c55e; }
+.btn-approve:hover { background: #22c55e; }
+.btn-deny { background: var(--auth-no); color: #fff; border-color: #ef4444; }
+.btn-deny:hover { background: #ef4444; }
+
+.response-badge {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 11px; margin-top: 6px;
+  padding: 3px 8px; border-radius: var(--radius);
+}
+.response-badge.approved { background: #14532d; color: #86efac; }
+.response-badge.denied { background: #450a0a; color: #fca5a5; }
+.response-badge.answered { background: var(--bg3); color: var(--text-dim); border: 1px solid var(--border); }
+
+.right-panel {
+  width: 240px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--border);
+  background: var(--bg1);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.panel-header {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.panel-body { flex: 1; overflow-y: auto; padding: 10px 14px; }
+
+.raw-toggle {
+  font-size: 10px;
+  color: var(--text-dim);
+  cursor: pointer;
+  border: none;
+  background: none;
+  font-family: var(--font);
+  padding: 2px 0;
+  margin-top: 4px;
+}
+.raw-toggle:hover { color: var(--accent-bright); }
+.raw-block {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px;
+  font-size: 10px;
+  color: #64748b;
+  max-height: 160px;
+  overflow: auto;
+  margin-top: 4px;
+  white-space: pre;
+  line-height: 1.5;
+}
+
+.statusbar {
+  height: 24px;
+  display: flex; align-items: center; gap: 12px;
+  padding: 0 16px;
+  background: var(--accent-dim);
+  border-top: 1px solid var(--accent);
+  font-size: 10px;
+  color: #a78bfa;
+  flex-shrink: 0;
+}
+.statusbar-item { display: flex; align-items: center; gap: 4px; }
+.statusbar-sep { width: 1px; height: 12px; background: var(--accent); opacity: 0.4; }
+
+.modal-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.7);
+  backdrop-filter: blur(2px);
+  z-index: 100;
+  display: flex; align-items: center; justify-content: center;
+  animation: fadeIn 0.15s ease-out;
+}
+.modal {
+  background: var(--bg1);
+  border: 1px solid var(--border2);
+  border-radius: 4px;
+  width: 540px;
+  max-width: 90vw;
+  max-height: 80vh;
+  display: flex; flex-direction: column;
+  box-shadow: 0 24px 64px rgba(0,0,0,0.8), 0 0 0 1px var(--border);
+  animation: modalIn 0.18s ease-out;
+}
+@keyframes modalIn { from { opacity: 0; transform: translateY(8px) scale(0.98); } to { opacity: 1; transform: none; } }
+.modal-header {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.modal-title { flex: 1; font-size: 12px; font-weight: 600; color: var(--text-bright); }
+.modal-close {
+  background: none; border: none; color: var(--text-dim); cursor: pointer;
+  font-size: 16px; line-height: 1; padding: 2px 6px; font-family: var(--font);
+  border-radius: var(--radius);
+}
+.modal-close:hover { color: var(--text); background: var(--bg3); }
+.modal-body { flex: 1; overflow-y: auto; padding: 18px; }
+.modal-section { margin-bottom: 14px; }
+.modal-section:last-child { margin-bottom: 0; }
+.modal-label {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.08em;
+  color: var(--text-dim); text-transform: uppercase; margin-bottom: 6px;
+}
+.modal-message {
+  font-size: 14px; color: var(--text-bright); line-height: 1.6;
+  background: var(--bg2); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 12px 14px;
+}
+.modal-meta-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.modal-meta-item {
+  background: var(--bg2); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 8px 10px;
+}
+.modal-meta-key { font-size: 10px; color: var(--text-dim); margin-bottom: 2px; }
+.modal-meta-val { font-size: 12px; color: var(--text-bright); }
+.modal-footer { padding: 14px 18px; border-top: 1px solid var(--border); flex-shrink: 0; }
+.modal-respond-row { display: flex; gap: 8px; align-items: flex-start; }
+.modal-respond-input {
+  flex: 1;
+  background: var(--bg3);
+  border: 1px solid var(--border2);
+  border-radius: var(--radius);
+  color: var(--text-bright);
+  font-family: var(--font);
+  font-size: 13px;
+  padding: 8px 12px;
+  outline: none;
+  transition: border-color 0.15s;
+  resize: vertical;
+  min-height: 38px;
+}
+.modal-respond-input:focus { border-color: var(--accent); }
+.modal-respond-input::placeholder { color: var(--text-dim); }
+
+.task-list { display: flex; flex-direction: column; gap: 0; }
+.task-item {
+  display: flex; align-items: flex-start; gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.1s;
+  position: relative;
+}
+.task-item:last-child { border-bottom: none; }
+.task-item:hover { background: var(--bg2); }
+.task-item.task-pending:hover { background: var(--bg3); }
+.task-status-icon {
+  width: 18px; height: 18px; border-radius: 50%;
+  flex-shrink: 0; margin-top: 1px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 9px; font-weight: 700;
+}
+.task-status-icon.pending { background: var(--bg3); border: 1.5px solid var(--border2); color: var(--text-dim); }
+.task-status-icon.approved { background: #14532d; border: 1.5px solid var(--auth-yes); color: #4ade80; }
+.task-status-icon.denied { background: #450a0a; border: 1.5px solid var(--auth-no); color: #fca5a5; }
+.task-status-icon.answered { background: var(--ask-dim); border: 1.5px solid var(--ask); color: #93c5fd; }
+.task-content { flex: 1; min-width: 0; }
+.task-type-row { display: flex; align-items: center; gap: 6px; margin-bottom: 3px; }
+.task-msg { font-size: 11px; color: var(--text); line-height: 1.4; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+.task-meta { font-size: 10px; color: var(--text-dim); margin-top: 3px; }
+.task-pending-pulse {
+  width: 6px; height: 6px; border-radius: 50%; background: var(--urgent);
+  animation: pulse 1.5s infinite; flex-shrink: 0; margin-top: 6px;
+}
+.task-list-empty { font-size: 11px; color: var(--text-dim); text-align: center; padding: 24px 0; opacity: 0.5; line-height: 1.8; }
+
+.scroll-notice {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--accent-dim);
+  border: 1px solid var(--accent);
+  border-radius: 12px;
+  padding: 4px 14px;
+  font-size: 11px;
+  color: var(--accent-bright);
+  cursor: pointer;
+  z-index: 10;
+  animation: fadeIn 0.2s;
+}
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel">
+const { useState, useEffect, useRef, useCallback, useMemo } = React;
+
+// Auto-detect WS URL: when served by ailoop --web the HTTP port is WS port + 1
+const wsDefault = (() => {
+  try {
+    const h = window.location.hostname || '127.0.0.1';
+    const p = window.location.port ? parseInt(window.location.port, 10) - 1 : 8080;
+    return `ws://${h}:${p}`;
+  } catch(_) { return 'ws://127.0.0.1:8080'; }
+})();
+
+function formatTs(iso) {
+  const d = new Date(iso);
+  const diff = Math.floor((Date.now() - d.getTime()) / 1000);
+  if (diff < 5) return 'just now';
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  return d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
+}
+
+function formatTsAbsolute(iso) {
+  return new Date(iso).toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+let eventIdCounter = 0;
+function makeId() { return ++eventIdCounter; }
+
+
+function getStripe(type) {
+  if (type === 'authorize') return 'stripe-authorize';
+  if (type === 'ask') return 'stripe-ask';
+  if (type === 'say') return 'stripe-say';
+  if (type === 'events') return 'stripe-events';
+  return 'stripe-unknown';
+}
+function getTypeClass(type) {
+  if (type === 'authorize') return 'type-authorize';
+  if (type === 'ask') return 'type-ask';
+  if (type === 'say') return 'type-say';
+  if (type === 'events') return 'type-events';
+  return 'type-error';
+}
+
+function RawBlock({ data }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button className="raw-toggle" onClick={(e) => { e.stopPropagation(); setOpen(o => !o); }}>
+        {open ? '▾ hide json' : '▸ raw json'}
+      </button>
+      {open && <pre className="raw-block">{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}
+
+function EventModal({ ev, onClose, onRespond }) {
+  const [answer, setAnswer] = useState('');
+
+  useEffect(() => {
+    function onKey(e) { if (e.key === 'Escape') onClose(); }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  function handleAskSend() {
+    if (!answer.trim()) return;
+    onRespond(ev, { type: 'answered', value: answer });
+    onClose();
+  }
+
+  function handleAuth(approved) {
+    onRespond(ev, { type: approved ? 'approved' : 'denied' });
+    onClose();
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={e => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="modal">
+        <div className="modal-header">
+          <span className={`event-type ${getTypeClass(ev.type)}`}>{ev.type}</span>
+          <span className="modal-title">{ev.channel && `#${ev.channel}`}</span>
+          {ev.responded && (
+            <span className={`response-badge ${ev.responded.type}`} style={{margin:0}}>
+              {ev.responded.type === 'approved' && '✓ approved'}
+              {ev.responded.type === 'denied' && '✗ denied'}
+              {ev.responded.type === 'answered' && '✓ answered'}
+            </span>
+          )}
+          <button className="modal-close" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="modal-body">
+          {ev.message && (
+            <div className="modal-section">
+              <div className="modal-label">
+                {ev.type === 'authorize' ? 'Action requiring approval' : ev.type === 'ask' ? 'Question' : 'Message'}
+              </div>
+              <div className="modal-message">{ev.message}</div>
+            </div>
+          )}
+
+          {ev.content && (
+            <div className="modal-section">
+              <div className="modal-label">Output</div>
+              <pre className="forward-content" style={{maxHeight:200}}>{ev.content}</pre>
+            </div>
+          )}
+
+          <div className="modal-section">
+            <div className="modal-meta-grid">
+              <div className="modal-meta-item">
+                <div className="modal-meta-key">channel</div>
+                <div className="modal-meta-val">{ev.channel || '—'}</div>
+              </div>
+              <div className="modal-meta-item">
+                <div className="modal-meta-key">received</div>
+                <div className="modal-meta-val">{formatTsAbsolute(ev.ts)}</div>
+              </div>
+              {ev.timeout && (
+                <div className="modal-meta-item">
+                  <div className="modal-meta-key">timeout</div>
+                  <div className="modal-meta-val">{ev.timeout}s</div>
+                </div>
+              )}
+              {ev.priority && ev.priority !== 'normal' && (
+                <div className="modal-meta-item">
+                  <div className="modal-meta-key">priority</div>
+                  <div className="modal-meta-val">
+                    <span className={`priority priority-${ev.priority}`}>{ev.priority}</span>
+                  </div>
+                </div>
+              )}
+              {ev.agent_type && (
+                <div className="modal-meta-item">
+                  <div className="modal-meta-key">agent</div>
+                  <div className="modal-meta-val">{ev.agent_type}</div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <RawBlock data={ev.raw || ev} />
+        </div>
+
+        {!ev.responded && (ev.type === 'ask' || ev.type === 'authorize') && (
+          <div className="modal-footer">
+            {ev.type === 'ask' && (
+              <div className="modal-respond-row">
+                <textarea
+                  className="modal-respond-input"
+                  placeholder="Type your answer… (Enter to send)"
+                  value={answer}
+                  autoFocus
+                  onChange={e => setAnswer(e.target.value)}
+                  onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleAskSend(); } }}
+                />
+                <button className="btn btn-respond btn-send" onClick={handleAskSend} style={{padding:'8px 18px'}}>Send ↵</button>
+              </div>
+            )}
+            {ev.type === 'authorize' && (
+              <div className="modal-respond-row" style={{gap:10}}>
+                <div style={{flex:1, fontSize:11, color:'var(--text-dim)', lineHeight:1.5}}>
+                  This action requires your explicit approval to proceed.
+                </div>
+                <button className="btn btn-respond btn-approve" style={{padding:'8px 20px'}} onClick={() => handleAuth(true)}>✓ Approve</button>
+                <button className="btn btn-respond btn-deny" style={{padding:'8px 20px'}} onClick={() => handleAuth(false)}>✗ Deny</button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {ev.responded && ev.responded.type === 'answered' && (
+          <div className="modal-footer">
+            <div style={{fontSize:12, color:'var(--text-dim)'}}>
+              Response sent: <span style={{color:'var(--text-bright)'}}>{ev.responded.value}</span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EventCard({ ev, onOpenModal }) {
+  const interactive = ev.type === 'ask' || ev.type === 'authorize';
+  const needsAction = interactive && !ev.responded;
+  return (
+    <div
+      className="event-card"
+      onClick={() => interactive && onOpenModal(ev)}
+      style={{ cursor: interactive ? 'pointer' : 'default' }}
+    >
+      <div className={`event-stripe ${getStripe(ev.type)}`}></div>
+      <div className="event-body">
+        <div className="event-meta">
+          <span className={`event-type ${getTypeClass(ev.type)}`}>{ev.type}</span>
+          {ev.channel && <span className="event-channel">ch:<span>{ev.channel}</span></span>}
+          {ev.priority && ev.priority !== 'normal' && (
+            <span className={`priority priority-${ev.priority}`}>{ev.priority}</span>
+          )}
+          {ev.timeout && <span className="event-channel">timeout:<span>{ev.timeout}s</span></span>}
+          {ev.agent_type && <span className="event-channel">agent:<span>{ev.agent_type}</span></span>}
+          <span className="event-ts">{formatTs(ev.ts)}</span>
+        </div>
+
+        {ev.message && <div className="event-msg">{ev.message}</div>}
+        {ev.content && <pre className="forward-content">{ev.content}</pre>}
+
+        {ev.type === 'ask' && ev.responded && ev.responded.type === 'answered' && (
+          <div className="response-badge answered">✓ answered</div>
+        )}
+        {ev.type === 'authorize' && ev.responded && ev.responded.type === 'approved' && (
+          <div className="response-badge approved">✓ approved</div>
+        )}
+        {ev.type === 'authorize' && ev.responded && ev.responded.type === 'denied' && (
+          <div className="response-badge denied">✗ denied</div>
+        )}
+
+        {needsAction && (
+          <div style={{fontSize:10, color:'var(--accent-bright)', marginTop:5, opacity:0.7}}>
+            ↗ click to respond
+          </div>
+        )}
+
+        <RawBlock data={ev.raw || ev} />
+      </div>
+    </div>
+  );
+}
+
+function getTaskStatus(ev) {
+  if (!ev.responded) return 'pending';
+  if (ev.responded.type === 'approved') return 'approved';
+  if (ev.responded.type === 'denied') return 'denied';
+  return 'answered';
+}
+
+function TaskItem({ ev, onOpenModal }) {
+  const status = getTaskStatus(ev);
+  const statusIcons = { pending: '○', approved: '✓', denied: '✗', answered: '✓' };
+  return (
+    <div className={`task-item task-${status}`} onClick={() => onOpenModal(ev)}>
+      <div className={`task-status-icon ${status}`}>{statusIcons[status]}</div>
+      <div className="task-content">
+        <div className="task-type-row">
+          <span className={`event-type ${getTypeClass(ev.type)}`} style={{fontSize:'9px'}}>{ev.type}</span>
+          {status === 'pending' && <span style={{fontSize:10, color:'var(--urgent)', fontWeight:600}}>pending</span>}
+        </div>
+        <div className="task-msg">{ev.message}</div>
+        <div className="task-meta">#{ev.channel} · {formatTs(ev.ts)}</div>
+      </div>
+      {status === 'pending' && <div className="task-pending-pulse"></div>}
+    </div>
+  );
+}
+
+function TaskList({ events, onOpenModal }) {
+  const tasks = events.filter(e => e.type === 'ask' || e.type === 'authorize');
+  const pending = tasks.filter(t => !t.responded);
+  const done = tasks.filter(t => t.responded);
+
+  if (tasks.length === 0) {
+    return (
+      <div className="task-list-empty">
+        No tasks yet.<br />
+        ask and authorize<br />events appear here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="task-list">
+      {pending.length > 0 && (
+        <>
+          <div style={{padding:'8px 14px 4px', fontSize:10, fontWeight:700, letterSpacing:'0.08em', color:'var(--urgent)', textTransform:'uppercase'}}>
+            Needs response ({pending.length})
+          </div>
+          {pending.map(ev => <TaskItem key={ev.id} ev={ev} onOpenModal={onOpenModal} />)}
+        </>
+      )}
+      {done.length > 0 && (
+        <>
+          <div style={{padding:'10px 14px 4px', fontSize:10, fontWeight:700, letterSpacing:'0.08em', color:'var(--text-dim)', textTransform:'uppercase', borderTop: pending.length > 0 ? '1px solid var(--border)' : 'none'}}>
+            Resolved ({done.length})
+          </div>
+          {done.map(ev => <TaskItem key={ev.id} ev={ev} onOpenModal={onOpenModal} />)}
+        </>
+      )}
+    </div>
+  );
+}
+
+function StatsPanel({ events }) {
+  const counts = { ask: 0, authorize: 0, say: 0, events: 0 };
+  events.forEach(e => { if (counts[e.type] !== undefined) counts[e.type]++; });
+  const pending = events.filter(e => (e.type === 'ask' || e.type === 'authorize') && !e.responded).length;
+  return (
+    <div className="stats-grid">
+      <div className="stat-row"><span className="stat-label">ask</span><span className="stat-val ask">{counts.ask}</span></div>
+      <div className="stat-row"><span className="stat-label">authorize</span><span className="stat-val auth">{counts.authorize}</span></div>
+      <div className="stat-row"><span className="stat-label">say</span><span className="stat-val say">{counts.say}</span></div>
+      <div className="stat-row"><span className="stat-label">events</span><span className="stat-val forward">{counts.events}</span></div>
+      <div className="stat-row" style={{borderTop:'1px solid var(--border)',paddingTop:6,marginTop:2}}>
+        <span className="stat-label">pending</span>
+        <span className="stat-val" style={{color: pending > 0 ? 'var(--urgent)' : 'var(--text-dim)'}}>{pending}</span>
+      </div>
+      <div className="stat-row">
+        <span className="stat-label">total</span>
+        <span className="stat-val" style={{color:'var(--text)'}}>{events.length}</span>
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  const [serverUrl, setServerUrl] = useState(wsDefault);
+  const [connState, setConnState] = useState('disconnected');
+  const [events, setEvents] = useState([]);
+  const [activeChannel, setActiveChannel] = useState('all');
+  const [typeFilter, setTypeFilter] = useState('all');
+  const [atBottom, setAtBottom] = useState(true);
+  const [modalEv, setModalEv] = useState(null);
+  const [, forceTick] = useState(0);
+
+  const wsRef = useRef(null);
+  const feedRef = useRef(null);
+  const seenServerIds = useRef(new Set());
+
+  // Tick once a minute so relative timestamps stay fresh.
+  useEffect(() => {
+    const id = setInterval(() => forceTick(t => t + 1), 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    if (feedRef.current) feedRef.current.scrollTop = feedRef.current.scrollHeight;
+  }, []);
+
+  function handleScroll() {
+    if (!feedRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = feedRef.current;
+    setAtBottom(scrollHeight - scrollTop - clientHeight < 40);
+  }
+
+  function addEvent(raw) {
+    // Normalise from the server's nested Message format
+    const sc = raw.content && typeof raw.content === 'object' ? raw.content : {};
+    const serverType = sc.type || '';
+
+    let type     = raw.type || raw.event_type || '';
+    let message  = raw.message || raw.msg || raw.prompt || raw.text || raw.question || '';
+    let content  = raw.output || '';
+    let timeout  = raw.timeout;
+    let priority = raw.priority || 'normal';
+    let agentType = raw.agent_type;
+
+    if (!type && serverType) {
+      if (serverType === 'question') {
+        type = 'ask'; message = sc.text || ''; timeout = sc.timeout_seconds;
+      } else if (serverType === 'authorization') {
+        type = 'authorize'; message = sc.action || ''; timeout = sc.timeout_seconds;
+      } else if (serverType === 'notification') {
+        type = 'say'; message = sc.text || ''; priority = sc.priority || 'normal';
+      } else if (serverType === 'navigate') {
+        type = 'navigate'; message = sc.url || '';
+      } else if (serverType === 'stdout' || serverType === 'stderr') {
+        type = 'events'; content = sc.content || ''; agentType = sc.state_name || '';
+      } else if (serverType === 'workflow_progress') {
+        type = 'events';
+        content = `${sc.workflow_name || ''} → ${sc.current_state || ''} (${sc.status || ''})`;
+      } else if (serverType === 'workflow_completed') {
+        type = 'events';
+        content = `${sc.workflow_name || ''} completed: ${sc.final_status || ''}`;
+      } else {
+        type = 'events'; content = JSON.stringify(sc);
+      }
+    }
+
+    // Deduplicate: if the event already arrived via WS history replay, skip
+    const serverId = raw.id || null;
+    if (serverId && seenServerIds.current.has(serverId)) return;
+    if (serverId) seenServerIds.current.add(serverId);
+
+    const ev = {
+      id: makeId(),
+      serverId,
+      ts: raw.timestamp || raw.ts || new Date().toISOString(),
+      type: type || 'unknown',
+      channel: raw.channel || raw.ch || 'public',
+      message,
+      content,
+      priority,
+      timeout,
+      agent_type: agentType,
+      responded: null,
+      raw,
+    };
+    setEvents(prev => [...prev, ev]);
+  }
+
+  function handleRespond(ev, response) {
+    // Optimistic local update
+    setEvents(prev => prev.map(e => e.id === ev.id ? { ...e, responded: response } : e));
+    // Submit to server via HTTP API when we have a real server message ID
+    if (ev.serverId) {
+      const responseType = response.type === 'approved' ? 'authorization_approved'
+                         : response.type === 'denied'   ? 'authorization_denied'
+                         : 'text';
+      fetch(`/api/v1/messages/${ev.serverId}/response`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ response_type: responseType, answer: response.value || null }),
+      }).catch(err => console.error('Response submit failed:', err));
+    }
+  }
+
+  useEffect(() => {
+    if (modalEv) {
+      const updated = events.find(e => e.id === modalEv.id);
+      if (updated && updated !== modalEv) setModalEv(updated);
+    }
+  }, [events]);
+
+  function seedFromApi() {
+    fetch('/api/channels')
+      .then(r => r.json())
+      .then(data => {
+        const channels = (data.channels || []).map(c => c.name);
+        channels.forEach(ch => {
+          fetch(`/api/channels/${encodeURIComponent(ch)}/messages?limit=500`)
+            .then(r => r.json())
+            .then(d => (d.messages || []).forEach(addEvent))
+            .catch(() => {});
+        });
+      })
+      .catch(() => {});
+  }
+
+  function connect() {
+    if (wsRef.current) wsRef.current.close();
+    setConnState('connecting');
+    try {
+      const ws = new WebSocket(serverUrl);
+      wsRef.current = ws;
+      ws.onopen = () => {
+        setConnState('connected');
+        // Register as viewer so the server sends broadcasts (not enqueue as agent)
+        ws.send(JSON.stringify({ subscribe: '*' }));
+        // Seed existing history from HTTP API (deduped by seenServerIds)
+        seedFromApi();
+      };
+      ws.onclose = () => setConnState('disconnected');
+      ws.onerror = () => setConnState('error');
+      ws.onmessage = (msg) => {
+        try {
+          const data = JSON.parse(msg.data);
+          const evs = Array.isArray(data) ? data : [data];
+          evs.forEach(raw => {
+            const c = raw.content && typeof raw.content === 'object' ? raw.content : {};
+            // Response messages update the responded state of their original event
+            if (c.type === 'response' && raw.correlation_id) {
+              const rt = c.response_type;
+              const responded = rt === 'authorization_approved' ? { type: 'approved' }
+                              : rt === 'authorization_denied'   ? { type: 'denied' }
+                              : { type: 'answered', value: c.answer || '' };
+              setEvents(prev => prev.map(e =>
+                e.serverId === raw.correlation_id ? { ...e, responded } : e
+              ));
+              return;
+            }
+            addEvent(raw);
+          });
+        } catch (e) {
+          addEvent({ type: 'events', channel: 'raw', content: msg.data, ts: new Date().toISOString() });
+        }
+      };
+    } catch (e) {
+      setConnState('error');
+    }
+  }
+
+  function disconnect() {
+    if (wsRef.current) { wsRef.current.close(); wsRef.current = null; }
+    setConnState('disconnected');
+  }
+
+  const channels = useMemo(() => {
+    const map = {};
+    events.forEach(e => { map[e.channel] = (map[e.channel] || 0) + 1; });
+    return map;
+  }, [events]);
+
+  const visibleEvents = useMemo(() => {
+    return events.filter(e => {
+      if (activeChannel !== 'all' && e.channel !== activeChannel) return false;
+      if (typeFilter !== 'all' && e.type !== typeFilter) return false;
+      return true;
+    });
+  }, [events, activeChannel, typeFilter]);
+
+  const pendingCount = events.filter(e => (e.type === 'ask' || e.type === 'authorize') && !e.responded).length;
+  const statusLabel = { disconnected: 'disconnected', connecting: 'connecting…', connected: 'connected', error: 'connection error' };
+
+  return (
+    <div id="app-root" style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <div className="topbar">
+        <div className="topbar-logo">
+          <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5"/>
+            <path d="M5 8h6M8 5l3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+          ailoop
+        </div>
+        <div className="topbar-sep"></div>
+        <div className="conn-form">
+          <input
+            className="conn-input"
+            value={serverUrl}
+            onChange={e => setServerUrl(e.target.value)}
+            placeholder="ws://127.0.0.1:8080"
+            disabled={connState === 'connected'}
+            onKeyDown={e => e.key === 'Enter' && connect()}
+          />
+          {(connState === 'disconnected' || connState === 'error') && (
+            <button className="btn btn-connect" onClick={connect}>Connect</button>
+          )}
+          {(connState === 'connected' || connState === 'connecting') && (
+            <button className="btn btn-disconnect" onClick={disconnect}>Disconnect</button>
+          )}
+        </div>
+        <div className="topbar-sep"></div>
+        <div className="status-indicator">
+          <div className={`status-dot ${connState}`}></div>
+          {statusLabel[connState]}
+        </div>
+      </div>
+
+      <div className="layout">
+        <div className="sidebar">
+          <div className="sidebar-section">
+            <div className="sidebar-label">Channels</div>
+            <div className={`channel-item ${activeChannel === 'all' ? 'active' : ''}`} onClick={() => setActiveChannel('all')}>
+              <div className={`ch-dot ${activeChannel === 'all' ? 'active' : ''}`}></div>
+              <span className="ch-name">all channels</span>
+              <span className="ch-count">{events.length}</span>
+            </div>
+            {Object.entries(channels).map(([ch, cnt]) => (
+              <div key={ch} className={`channel-item ${activeChannel === ch ? 'active' : ''}`} onClick={() => setActiveChannel(ch)}>
+                <div className={`ch-dot ${activeChannel === ch ? 'active' : ''}`}></div>
+                <span className="ch-name">{ch}</span>
+                <span className="ch-count">{cnt}</span>
+              </div>
+            ))}
+          </div>
+          <div className="sidebar-section" style={{ flex: 1 }}>
+            <div className="sidebar-label">Stats</div>
+            <StatsPanel events={events} />
+          </div>
+        </div>
+
+        <div className="feed-area" style={{ position: 'relative' }}>
+          <div className="feed-toolbar">
+            {['all', 'ask', 'authorize', 'say', 'events'].map(f => (
+              <button
+                key={f}
+                className={`filter-btn ${typeFilter === f ? `active-${f}` : ''}`}
+                onClick={() => setTypeFilter(f)}
+              >
+                {f}
+              </button>
+            ))}
+            <div className="feed-toolbar-right">
+              <button className="btn-clear" onClick={() => { setEvents([]); seenServerIds.current.clear(); }}>clear</button>
+              <button className="scroll-btn" onClick={scrollToBottom}>↓ bottom</button>
+            </div>
+          </div>
+
+          <div className="feed" ref={feedRef} onScroll={handleScroll}>
+            {visibleEvents.length === 0 ? (
+              <div className="feed-empty">
+                <div className="feed-empty-icon">◉</div>
+                <div className="feed-empty-text">
+                  {connState === 'disconnected' || connState === 'error'
+                    ? 'Connect to an ailoop server'
+                    : 'Listening for events…\nailoop forward --channel public'}
+                </div>
+              </div>
+            ) : (
+              visibleEvents.map(ev => (
+                <EventCard key={ev.id} ev={ev} onOpenModal={setModalEv} />
+              ))
+            )}
+          </div>
+
+          {!atBottom && visibleEvents.length > 0 && (
+            <div className="scroll-notice" onClick={scrollToBottom}>↓ scroll to latest</div>
+          )}
+        </div>
+
+        <div className="right-panel">
+          <div className="panel-header" style={{display:'flex', alignItems:'center', justifyContent:'space-between'}}>
+            <span>Tasks</span>
+            {pendingCount > 0 && (
+              <span style={{background:'var(--urgent)', color:'#fff', fontSize:10, fontWeight:700, padding:'1px 7px', borderRadius:10}}>
+                {pendingCount}
+              </span>
+            )}
+          </div>
+          <div className="panel-body" style={{padding:0}}>
+            <TaskList events={events} onOpenModal={setModalEv} />
+          </div>
+        </div>
+      </div>
+
+      <div className="statusbar">
+        <div className="statusbar-item">ailoop</div>
+        <div className="statusbar-sep"></div>
+        <div className="statusbar-item">v0.1</div>
+        <div className="statusbar-sep"></div>
+        <div className="statusbar-item">{connState === 'connected' ? serverUrl : '—'}</div>
+        <div className="statusbar-sep"></div>
+        <div className="statusbar-item">{Object.keys(channels).length} ch · {events.length} events</div>
+        <div className="statusbar-item" style={{ marginLeft: 'auto' }}>
+          {new Date().toLocaleTimeString('en-US', { hour12: false })}
+        </div>
+      </div>
+
+      {modalEv && (
+        <EventModal
+          ev={modalEv}
+          onClose={() => setModalEv(null)}
+          onRespond={handleRespond}
+        />
+      )}
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>

--- a/ailoop-core/src/server/broadcast.rs
+++ b/ailoop-core/src/server/broadcast.rs
@@ -135,6 +135,16 @@ impl BroadcastManager {
         Ok(())
     }
 
+    /// Switch a connection to Viewer mode (called when browser sends hello frame)
+    pub async fn set_viewer_mode(&self, connection_id: &Uuid) -> Result<(), String> {
+        let mut viewers = self.viewers.write().await;
+        let viewer = viewers
+            .get_mut(connection_id)
+            .ok_or_else(|| format!("Viewer {} not found", connection_id))?;
+        viewer.connection_type = ConnectionType::Viewer;
+        Ok(())
+    }
+
     /// Subscribe a viewer to all channels
     pub async fn subscribe_to_all(&self, connection_id: &Uuid) -> Result<(), String> {
         let mut viewers = self.viewers.write().await;
@@ -145,6 +155,12 @@ impl BroadcastManager {
         // Get all available channels (this would come from message history)
         // For now, we'll add a special marker for "all channels"
         viewer.subscribed_channels.insert("*".to_string());
+
+        let mut channel_subs = self.channel_subscriptions.write().await;
+        channel_subs
+            .entry("*".to_string())
+            .or_insert_with(HashSet::new)
+            .insert(*connection_id);
 
         Ok(())
     }

--- a/ailoop-core/src/server/core.rs
+++ b/ailoop-core/src/server/core.rs
@@ -19,6 +19,7 @@ use std::sync::{
 use tokio::net::TcpListener;
 use tokio::time::{interval, Duration};
 use tokio_tungstenite::{accept_async, tungstenite::Message as WsMessage};
+use warp::Filter;
 
 /// Main ailoop server
 pub struct AiloopServer {
@@ -31,6 +32,8 @@ pub struct AiloopServer {
     task_storage: Arc<crate::server::task_storage::TaskStorage>,
     pending_prompt_registry: Arc<PendingPromptRegistry>,
     config: Option<Configuration>,
+    /// Whether to serve the embedded web UI on the HTTP port
+    web: bool,
 }
 
 /// Server status for UI
@@ -61,12 +64,19 @@ impl AiloopServer {
             task_storage,
             pending_prompt_registry,
             config: None,
+            web: false,
         }
     }
 
     /// Attach configuration (for provider loading at startup).
     pub fn with_config(mut self, config: Configuration) -> Self {
         self.config = Some(config);
+        self
+    }
+
+    /// Enable the embedded web UI served on the HTTP port.
+    pub fn with_web(mut self, enable: bool) -> Self {
+        self.web = enable;
         self
     }
 
@@ -160,22 +170,38 @@ impl AiloopServer {
         // Spawn HTTP API server task (use port + 1 for HTTP API)
         let http_port = self.port + 1;
         let http_host = self.host.clone();
+        let enable_web = self.web;
         println!("HTTP API server starting on {}:{}", http_host, http_port);
-        let api_task = tokio::spawn(async move {
-            println!("HTTP API task spawned");
-            let addr = format!("{}:{}", http_host, http_port);
-            match addr.parse::<std::net::SocketAddr>() {
-                Ok(socket_addr) => {
-                    println!("HTTP API server attempting to bind to {}", socket_addr);
-                    warp::serve(api_routes).run(socket_addr).await;
-                    println!(" HTTP API server task completed");
+        if enable_web {
+            println!("Web UI available at http://{}:{}/", http_host, http_port);
+        }
+        let api_task = if enable_web {
+            let ui = crate::server::web::ui_route();
+            let routes = ui.or(api_routes);
+            tokio::spawn(async move {
+                let addr = format!("{}:{}", http_host, http_port);
+                match addr.parse::<std::net::SocketAddr>() {
+                    Ok(socket_addr) => {
+                        warp::serve(routes).run(socket_addr).await;
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to parse HTTP API address {}: {}", addr, e);
+                    }
                 }
-                Err(e) => {
-                    eprintln!("Failed to parse HTTP API address {}: {}", addr, e);
+            })
+        } else {
+            tokio::spawn(async move {
+                let addr = format!("{}:{}", http_host, http_port);
+                match addr.parse::<std::net::SocketAddr>() {
+                    Ok(socket_addr) => {
+                        warp::serve(api_routes).run(socket_addr).await;
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to parse HTTP API address {}: {}", addr, e);
+                    }
                 }
-            }
-        });
-        println!("HTTP API task spawn requested");
+            })
+        };
 
         // Spawn message processing task
         let channel_manager_msg = Arc::clone(&self.channel_manager);
@@ -255,9 +281,10 @@ impl AiloopServer {
 
         let (mut ws_sender, mut ws_receiver) = ws_stream.split();
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let tx_replay = tx.clone(); // retained for viewer history replay
         let mut channel_name = default_channel.clone();
 
-        // Determine connection type (default to Agent, can be changed by protocol)
+        // Connections start as Agent; the browser sends a hello frame to become a Viewer
         let connection_type = crate::server::broadcast::ConnectionType::Agent;
         let connection_id = broadcast_manager.add_viewer(connection_type, tx).await;
 
@@ -275,10 +302,42 @@ impl AiloopServer {
         });
 
         // Handle incoming messages
+        let mut is_viewer = false;
         while let Some(msg) = ws_receiver.next().await {
             match msg {
                 Ok(WsMessage::Text(text)) => {
-                    // Parse incoming message
+                    // Check for viewer hello frame: {"subscribe": "*"} or {"subscribe": [...]}
+                    // Must be checked before trying to parse as a Message.
+                    if !is_viewer {
+                        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&text) {
+                            if val.get("subscribe").is_some() {
+                                is_viewer = true;
+                                broadcast_manager.set_viewer_mode(&connection_id).await.ok();
+                                broadcast_manager
+                                    .subscribe_to_all(&connection_id)
+                                    .await
+                                    .ok();
+                                // Replay history so the page is not blank on connect
+                                let channels = message_history.get_channels().await;
+                                for ch in channels {
+                                    let msgs = message_history.get_messages(&ch, Some(500)).await;
+                                    for m in msgs {
+                                        if let Ok(j) = serde_json::to_string(&m) {
+                                            let _ = tx_replay.send(WsMessage::Text(j));
+                                        }
+                                    }
+                                }
+                                continue;
+                            }
+                        }
+                    }
+
+                    if is_viewer {
+                        // Viewers are read-only; they submit responses via HTTP API
+                        continue;
+                    }
+
+                    // Agent path: parse and enqueue the message
                     match serde_json::from_str::<Message>(&text) {
                         Ok(message) => {
                             // Update channel if specified
@@ -310,8 +369,6 @@ impl AiloopServer {
                                 history_clone
                                     .add_message(&channel_clone2, message_clone.clone())
                                     .await;
-                                // For interactive messages, broadcast to viewers only
-                                // (notification sinks are handled separately to get reply-to ID)
                                 if is_interactive {
                                     broadcast_clone2
                                         .broadcast_to_viewers_only(&message_clone)
@@ -323,8 +380,6 @@ impl AiloopServer {
 
                             // Enqueue message
                             channel_manager.enqueue_message(&channel_name, message);
-
-                            // Message queued (logged silently to avoid interfering with prompts)
                         }
                         Err(e) => {
                             eprintln!("[{}] Failed to parse message: {}", addr, e);
@@ -332,7 +387,6 @@ impl AiloopServer {
                     }
                 }
                 Ok(WsMessage::Close(_)) => {
-                    // Connection closed normally by client
                     break;
                 }
                 Err(e) => {
@@ -346,7 +400,9 @@ impl AiloopServer {
         // Cleanup
         forward_task.abort();
         broadcast_manager.remove_viewer(&connection_id).await;
-        channel_manager.remove_connection(&channel_name);
+        if !is_viewer {
+            channel_manager.remove_connection(&channel_name);
+        }
 
         Ok(())
     }

--- a/ailoop-core/src/server/mod.rs
+++ b/ailoop-core/src/server/mod.rs
@@ -5,6 +5,7 @@ pub mod history;
 pub mod providers;
 pub mod queue;
 pub mod task_storage;
+pub mod web;
 pub mod websocket;
 
 pub use core::AiloopServer;

--- a/ailoop-core/src/server/web.rs
+++ b/ailoop-core/src/server/web.rs
@@ -1,0 +1,20 @@
+//! Embedded web UI served by `ailoop serve --web`
+
+use warp::Filter;
+
+pub static UI_HTML: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/assets/ailoop-ui.html"
+));
+
+/// Warp route: GET / → serves the embedded HTML UI
+pub fn ui_route() -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone
+{
+    warp::path::end().and(warp::get()).map(|| {
+        warp::http::Response::builder()
+            .status(200)
+            .header("content-type", "text/html; charset=utf-8")
+            .body(UI_HTML)
+            .unwrap()
+    })
+}

--- a/ailoop-core/tests/provider_broadcast_sink_test.rs
+++ b/ailoop-core/tests/provider_broadcast_sink_test.rs
@@ -1,11 +1,13 @@
 //! Integration test: broadcast invokes registered notification sinks; delivery failure is logged.
 
 use ailoop_core::models::{Message, MessageContent, SenderType};
-use ailoop_core::server::broadcast::BroadcastManager;
+use ailoop_core::server::broadcast::{BroadcastManager, ConnectionType};
 use ailoop_core::server::providers::NotificationSink;
 use async_trait::async_trait;
 use std::sync::Arc;
+use tokio::sync::mpsc;
 use tokio::sync::RwLock;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
 
 /// Mock sink that records received messages.
 struct MockSink {
@@ -101,4 +103,31 @@ async fn test_broadcast_with_failing_sink_completes() {
 
     let messages = received.read().await;
     assert_eq!(messages.len(), 1, "successful sink still receives message");
+}
+
+#[tokio::test]
+async fn subscribe_to_all_delivers_broadcasts_for_any_channel() {
+    let manager = BroadcastManager::new();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let connection_id = manager.add_viewer(ConnectionType::Viewer, tx).await;
+    manager.subscribe_to_all(&connection_id).await.unwrap();
+
+    let message = Message::new(
+        "some-channel".to_string(),
+        SenderType::Agent,
+        MessageContent::Notification {
+            text: "live".to_string(),
+            priority: ailoop_core::models::NotificationPriority::Normal,
+        },
+    );
+
+    manager.broadcast_message(&message).await;
+
+    let ws = rx
+        .try_recv()
+        .expect("subscribe * must register channel_subscriptions");
+    match ws {
+        WsMessage::Text(s) => assert!(s.contains("live")),
+        other => panic!("expected Text broadcast, got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `ailoop serve --web`: serves the embedded single-file HTML/JS/CSS UI on the HTTP API port (`port+1`, default `http://127.0.0.1:8081/`).
- Asset lives at `ailoop-core/assets/ailoop-ui.html` and is compiled into the binary via `include_str!` — no extra files needed at runtime.
- Browser connects to the WebSocket as a **Viewer** (sends `{"subscribe":"*"}` hello frame); server switches the connection type, replays message history, and broadcasts all subsequent events.
- `ask` / `authorize` responses submitted from the UI call `POST /api/v1/messages/:id/response`, which unblocks the waiting CLI command or Telegram prompt.
- Removed the demo button and all demo-related functionality from the UI (no longer needed now that real data is wired).
- Documents `AILOOP_SERVER` env var in README and skill file so users can skip `--server` on every command.
