### PR TITLE
docs: vendor skill into monorepo and document ailoop-py WebSocket streaming

### DIFF
--- a/ailoop-py/README.md
+++ b/ailoop-py/README.md
@@ -28,6 +28,16 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## WebSocket streaming
+
+**Handlers must be registered before entering `async with AiloopClient(...)`.**
+`__aenter__` immediately spawns the background receive loop — handlers registered after that point can miss messages silently.
+
+See [`examples/streaming_agent.py`](examples/streaming_agent.py) for a complete runnable example covering handlers, channel subscription, `ask`, correlated reply, and clean shutdown.
+
+Full SDK reference (connection lifecycle, correlation ID matching, manual lifecycle, workflow scope):
+[`skill/ailoop/references/ailoop-py.md`](../skill/ailoop/references/ailoop-py.md) (monorepo-relative path).
+
 ## Capabilities
 
 - Send `ask`, `authorize`, `say`, and `navigate`

--- a/ailoop-py/examples/streaming_agent.py
+++ b/ailoop-py/examples/streaming_agent.py
@@ -1,0 +1,51 @@
+"""
+Complete runnable example: ailoop-py streaming agent with WebSocket.
+
+Registers handlers before entering async context manager, subscribes to a channel,
+sends an ask, and waits for the correlated human response before exiting cleanly.
+
+Run (requires a running ailoop server):
+    python examples/streaming_agent.py
+"""
+import asyncio
+
+from ailoop import AiloopClient
+
+
+async def main() -> None:
+    pending: dict[str, asyncio.Future] = {}
+    stop = asyncio.Event()
+
+    async def on_message(data: dict) -> None:
+        content = data.get("content", {})
+        msg_type = content.get("type")
+        cid = data.get("correlation_id")
+        if msg_type == "response" and cid and cid in pending:
+            pending[cid].set_result(data)
+            stop.set()
+        else:
+            print(f"[message] type={msg_type} channel={data.get('channel')}")
+
+    async def on_connection(event: dict) -> None:
+        print(f"[connection] {event['type']}")
+
+    client = AiloopClient("http://127.0.0.1:8080", channel="public")
+    # Handlers MUST be registered before entering the async context manager.
+    # __aenter__ immediately calls connect_websocket(), which spawns the
+    # background receive loop — any handler registered after that point can
+    # miss messages (including the initial "connected" event).
+    client.add_message_handler(on_message)
+    client.add_connection_handler(on_connection)
+
+    async with client:
+        await client.subscribe_to_channel("public")
+        sent = await client.ask("Proceed with deployment?", timeout=120)
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        pending[str(sent.id)] = fut
+        await stop.wait()
+        reply = fut.result()
+        print(f"[reply] {reply['content'].get('answer')}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/skill/.github/workflows/publish-skill.yml
+++ b/skill/.github/workflows/publish-skill.yml
@@ -1,0 +1,124 @@
+name: Publish Ailoop Skill
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ailoop/**'
+      - '.github/workflows/publish-skill.yml'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 1.2.3)'
+        required: false
+      force:
+        description: 'Force package even if no changes detected'
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install FastSkill CLI
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/gofastskill/fastskill/main/scripts/install.sh | bash
+          fastskill --version
+
+      - name: Detect changes
+        id: detect
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            FORCE="${{ inputs.force || 'false' }}"
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "force=$FORCE" >> $GITHUB_OUTPUT
+          else
+            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD | grep '^ailoop/' || echo "")
+            if [ -n "$CHANGED_FILES" ]; then
+              echo "changed=true" >> $GITHUB_OUTPUT
+              echo "force=true" >> $GITHUB_OUTPUT
+            else
+              echo "changed=false" >> $GITHUB_OUTPUT
+              echo "force=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(grep '^version = ' ailoop/skill-project.toml | sed 's/version = "\([^"]*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Package skill using FastSkill
+        if: steps.detect.outputs.changed == 'true' || steps.detect.outputs.force == 'true'
+        run: |
+          # Package ailoop skill using fastskill CLI
+          # Skills are in repository root
+          fastskill package \
+            --skills-dir . \
+            --skills ailoop \
+            --force \
+            --output ./artifacts
+
+      - name: Generate GitHub App Token
+        id: app-token
+        if: steps.detect.outputs.changed == 'true' || steps.detect.outputs.force == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Delete old releases
+        if: steps.detect.outputs.changed == 'true' || steps.detect.outputs.force == 'true'
+        run: |
+          # Delete any releases with incorrect or old tags
+          for tag in $(gh release list --json tagName --jq '.[].tagName'); do
+            if [ "$tag" = "v" ] || [ "$tag" != "v${{ steps.version.outputs.version }}" ]; then
+              echo "Deleting release $tag"
+              gh release delete "$tag" --yes --cleanup-tag || true
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Create GitHub Release
+        if: steps.detect.outputs.changed == 'true' || steps.detect.outputs.force == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Ailoop Skill v${{ steps.version.outputs.version }}
+          body: |
+            Ailoop - Human-in-the-loop CLI for AI agent communication
+
+            ## What's New
+
+            See [changelog](https://github.com/${{ github.repository }}/blob/main/ailoop/SKILL.md) for details.
+
+            ## Installation
+
+            Add this skill to your project:
+
+            ```bash
+            # Install this skill
+            fastskill add https://github.com/${{ github.repository }}.git
+            ```
+
+            ## Contents
+
+            - SKILL.md: Comprehensive skill documentation
+            - skill-project.toml: Skill configuration and metadata
+          files: ./artifacts/*.zip
+          fail_on_unmatched_files: false
+          draft: false
+          prerelease: false
+          generate_release_notes: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/skill/CONTRIBUTING.md
+++ b/skill/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to Ailoop Skill
+
+## Repository Structure
+
+```
+goailoop/skill/
+├── skill-project.toml       # Project-level configuration
+└── ailoop/                  # Ailoop skill
+    ├── SKILL.md             # Skill documentation
+    └── skill-project.toml   # Skill metadata
+```
+
+## Development
+
+1. Edit files in `ailoop/` subdirectory
+2. Commit and push to `main` branch
+3. The CI/CD workflow will automatically package and publish a new release when `ailoop/` or the workflow file changes
+
+## CI/CD
+
+The GitHub Actions workflow in `.github/workflows/publish-skill.yml`:
+
+- Triggers on push to `main` when paths `ailoop/**` or `.github/workflows/publish-skill.yml` change, or on workflow_dispatch
+- Packages the skill using FastSkill CLI
+- Creates a GitHub release with the packaged skill artifact
+- Uses a GitHub App token for release operations (delete old releases)
+
+## Required Secrets
+
+Configure these repository secrets for the publish workflow:
+
+- `GH_APP_ID`: GitHub App ID for token generation
+- `GH_APP_PRIVATE_KEY`: GitHub App private key for authentication
+- `GITHUB_TOKEN`: Provided automatically by GitHub Actions
+
+Ensure the GitHub App has **Repository → Contents: Read and write** on this repository.

--- a/skill/LICENSE
+++ b/skill/LICENSE
@@ -1,0 +1,17 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skill/README.md
+++ b/skill/README.md
@@ -1,0 +1,17 @@
+# Ailoop Skill Repository
+
+This repository contains the Ailoop skill for AI Agent Skills. Use the FastSkill CLI to install and use it.
+
+## Installation
+
+From your project root:
+
+```bash
+fastskill add https://github.com/goailoop/skill.git
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development and release details.
+
+## License
+
+Apache-2.0

--- a/skill/ailoop/SKILL.md
+++ b/skill/ailoop/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: ailoop
+description: Human-in-the-loop CLI for AI agent communication. Use when agents need to ask questions, request authorization, send notifications, run server mode, or forward messages; integrating ailoop SDK (Python/TypeScript) or configuring channels and providers.
+license: Apache-2.0
+---
+
+# Ailoop
+
+Ailoop is a CLI and server that lets AI agents talk to humans in a structured way: ask questions, request authorization, send notifications, and forward agent output. Use this skill when you need to add human-in-the-loop flows or integrate ailoop into an agent or app.
+
+## When to use
+
+- An agent must ask a human a question and wait for an answer.
+- An agent needs approval before a critical action (e.g. deploy, delete).
+- Sending notifications (build done, alerts) to humans or channels.
+- Running a central server for multiple agents (server mode).
+- Forwarding agent output to a server or channel.
+- Integrating ailoop from Python or TypeScript (SDK).
+- Configuring channels or providers (e.g. Telegram).
+- Managing tasks with states and dependency graphs.
+- Orchestrating workflows with approval gates.
+
+## Core Concepts
+
+### Message types
+
+| Type | Direction | Description |
+|------|-----------|-------------|
+| **ask** | Agent -> Human | Ask a question, optionally with multiple choices. Blocks until answered. |
+| **authorize** | Agent -> Human | Request approval. Defaults to **denied** on timeout or interruption. |
+| **say** | Agent -> Human | One-way notification with priority levels. |
+| **image** | Agent -> Human | Display an image (file path or URL). |
+| **navigate** | Agent -> Human | Suggest user navigate to a URL. |
+| **response** | Human -> Agent | Reply to a question or authorization request. |
+
+### Channels
+
+Channels isolate workflows. Names: 1-64 chars, lowercase alphanumeric, hyphens, underscores; must start with letter or digit. Default channel is `public`.
+
+### Architecture
+
+```
+Agent/CLI --> HTTP REST API --> ailoop serve <-- WebSocket --> SDK clients
+             POST /api/v1/messages         |
+             GET  /api/v1/messages/{id}     +-- Telegram provider
+             GET  /api/v1/tasks             +-- Terminal (TTY)
+             ws://{host}/ws
+```
+
+The server (`ailoop serve`) is the central hub. CLI commands and SDK clients communicate with it via HTTP and WebSocket.
+
+## Environment Variables
+
+Variables that apply across CLI, server, and SDK clients:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AILOOP_SERVER` | Server URL for remote operation. Takes precedence over `--server` CLI flag. URL is auto-converted (http->ws, https->wss). | None |
+| `AILOOP_TELEGRAM_BOT_TOKEN` | Telegram Bot API token. Required when Telegram provider is enabled. | None |
+| `RUST_LOG` | Server logging verbosity (used by `ailoop serve`). | `ailoop=info` |
+| `XDG_CONFIG_HOME` | Base config directory. Config file: `$XDG_CONFIG_HOME/ailoop/config.toml`. | `~/.config` |
+
+The Python and TypeScript SDKs do **not** read environment variables -- all configuration is passed via constructor parameters.
+
+For CLI-specific environment variables and full details, see [`references/ailoop-cli.md`](references/ailoop-cli.md).
+
+## Detailed References
+
+For complete documentation, see:
+
+- **CLI**: [`references/ailoop-cli.md`](references/ailoop-cli.md) -- all commands, flags, task management, workflow orchestration, provider setup
+- **API**: [`references/ailoop-api.md`](references/ailoop-api.md) -- REST endpoints, WebSocket protocol, message schemas, curl examples
+- **Python SDK**: [`references/ailoop-py.md`](references/ailoop-py.md) -- `AiloopClient` API, WebSocket listening, models, task management
+- **TypeScript SDK**: [`references/ailoop-js.md`](references/ailoop-js.md) -- `AiloopClient` API, `MessageFactory`, types, WebSocket listening
+
+## Quick Start
+
+### CLI
+
+```bash
+# Install
+brew install goailoop/cli/ailoop
+
+# Ask a question (blocks until answered)
+ailoop ask "What is the best approach?"
+
+# Request authorization (denied on timeout)
+ailoop authorize "Deploy v1.2.3 to production" --timeout 300
+
+# Send a notification
+ailoop say "Build completed" --priority high
+
+# Start server for multi-agent use
+ailoop serve
+```
+
+### Python
+
+```bash
+pip install ailoop-py
+```
+
+```python
+from ailoop import AiloopClient
+
+async with AiloopClient(server_url="http://localhost:8080") as client:
+    msg = await client.ask("Ready to proceed?", channel="dev")
+    await client.say("Task completed", channel="dev", priority="normal")
+```
+
+### TypeScript
+
+```bash
+npm install ailoop-js
+```
+
+```typescript
+import { AiloopClient } from 'ailoop-js';
+
+const client = new AiloopClient({ baseURL: 'http://localhost:8080' });
+const msg = await client.ask('dev', 'Ready to proceed?');
+await client.say('dev', 'Task completed', 'normal');
+```
+
+## Getting help
+
+- `ailoop --version`, `ailoop <command> --help`
+- [GitHub](https://github.com/goailoop/ailoop)

--- a/skill/ailoop/SKILL.md
+++ b/skill/ailoop/SKILL.md
@@ -18,7 +18,7 @@ Ailoop is a CLI and server that lets AI agents talk to humans in a structured wa
 - Integrating ailoop from Python or TypeScript (SDK).
 - Configuring channels or providers (e.g. Telegram).
 - Managing tasks with states and dependency graphs.
-- Orchestrating workflows with approval gates.
+- Orchestrating workflows with approval gates. *(preview — CLI only; not yet covered in SDK examples — do not generate Python SDK workflow code)*
 
 ## Core Concepts
 
@@ -68,7 +68,7 @@ For CLI-specific environment variables and full details, see [`references/ailoop
 
 For complete documentation, see:
 
-- **CLI**: [`references/ailoop-cli.md`](references/ailoop-cli.md) -- all commands, flags, task management, workflow orchestration, provider setup
+- **CLI**: [`references/ailoop-cli.md`](references/ailoop-cli.md) -- all commands, flags, task management, workflow orchestration (CLI-only / preview — not supported in Python/TypeScript SDK integrations), provider setup
 - **API**: [`references/ailoop-api.md`](references/ailoop-api.md) -- REST endpoints, WebSocket protocol, message schemas, curl examples
 - **Python SDK**: [`references/ailoop-py.md`](references/ailoop-py.md) -- `AiloopClient` API, WebSocket listening, models, task management
 - **TypeScript SDK**: [`references/ailoop-js.md`](references/ailoop-js.md) -- `AiloopClient` API, `MessageFactory`, types, WebSocket listening

--- a/skill/ailoop/references/ailoop-api.md
+++ b/skill/ailoop/references/ailoop-api.md
@@ -1,0 +1,664 @@
+# ailoop API Reference
+
+HTTP REST API and WebSocket protocol exposed by `ailoop serve`. This is the transport layer that the CLI, Python SDK, and TypeScript SDK all use to communicate with the server.
+
+## Server Endpoints
+
+The server exposes two ports:
+
+| Service | Default Address | Configurable |
+|---------|----------------|--------------|
+| WebSocket | `{host}:{port}` (default `127.0.0.1:8080`) | `ailoop serve --host --port` |
+| HTTP REST API | `{host}:{port+1}` (default `127.0.0.1:8081`) | Derived from WS port |
+
+No authentication or API key is required.
+
+---
+
+## HTTP REST API (v1)
+
+Base path: `/api/v1`
+
+### Health
+
+#### `GET /api/v1/health`
+
+Health check and version info.
+
+**Response 200:**
+
+```json
+{
+  "status": "healthy",
+  "version": "0.1.7",
+  "active_connections": 3,
+  "queue_size": 0,
+  "active_channels": 2
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | `string` | Always `"healthy"` |
+| `version` | `string` | Server version |
+| `active_connections` | `number` | Connected WebSocket clients |
+| `queue_size` | `number` | Pending messages in queue |
+| `active_channels` | `number` | Channels with messages |
+
+---
+
+### Messages
+
+#### `POST /api/v1/messages`
+
+Send a message. The message is stored in channel history and broadcast to all WebSocket subscribers on that channel.
+
+**Request body:**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "channel": "my-channel",
+  "sender_type": "AGENT",
+  "content": { "type": "notification", "text": "Hello", "priority": "normal" },
+  "timestamp": "2026-05-02T12:00:00Z",
+  "correlation_id": null,
+  "metadata": null
+}
+```
+
+**Response 201:** The created `Message` (JSON).
+
+**Channel validation:** 1-64 chars, starts with alphanumeric, only `[a-zA-Z0-9_-]`. Reserved names rejected: `system`, `admin`, `internal`, `reserved`, `ailoop`.
+
+See [Message content types](#message-content-types) below for all valid `content` payloads.
+
+---
+
+#### `GET /api/v1/messages/:id`
+
+Retrieve a message by its UUID.
+
+**Response 200:** `Message` (JSON).
+
+**Response 404:**
+
+```json
+{"error": "Message not found", "message_id": "..."}
+```
+
+---
+
+#### `POST /api/v1/messages/:id/response`
+
+Send a response to an existing message. If a terminal or Telegram prompt is waiting on the server, this completes it.
+
+**Request body:**
+
+```json
+{
+  "answer": "Yes, proceed",
+  "response_type": "text"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `answer` | `string \| null` | Response text |
+| `response_type` | `string` | See [Response types](#response-types) |
+
+**Response 200:** The created response `Message` (with `correlation_id` set to the original message's `id`).
+
+**Response 404:**
+
+```json
+{"error": "Original message not found", "message_id": "..."}
+```
+
+---
+
+### Tasks
+
+#### `POST /api/v1/tasks`
+
+Create a new task.
+
+**Request body:**
+
+```json
+{
+  "title": "Deploy service",
+  "description": "Deploy v2 to staging",
+  "channel": "ops",
+  "assignee": "alice",
+  "metadata": {"priority": "high"}
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `title` | `string` | yes | Task title |
+| `description` | `string` | yes | Task description |
+| `channel` | `string` | yes | Channel scope |
+| `assignee` | `string \| null` | no | Assignee |
+| `metadata` | `object \| null` | no | Custom metadata |
+
+**Response 201:** `Task` (JSON). See [Task schema](#task-schema).
+
+---
+
+#### `GET /api/v1/tasks`
+
+List tasks, optionally filtered by state.
+
+**Query parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `channel` | `string` | yes | Channel scope |
+| `state` | `string` | no | Filter: `pending`, `done`, `abandoned` |
+
+**Response 200:**
+
+```json
+{
+  "channel": "ops",
+  "tasks": [...],
+  "total_count": 5
+}
+```
+
+Tasks are sorted by `created_at`.
+
+---
+
+#### `GET /api/v1/tasks/:id`
+
+Get a task by UUID.
+
+**Query parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `channel` | `string` | `public` | Channel scope |
+
+**Response 200:** `Task` (JSON).
+
+**Response 404:** `{"error": "Task not found", "task_id": "..."}`
+
+---
+
+#### `PUT /api/v1/tasks/:id`
+
+Update a task's state. Triggers cascading blocked-status recalculation on dependent tasks.
+
+**Query parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `channel` | `string` | `public` | Channel scope |
+
+**Request body:**
+
+```json
+{"state": "done"}
+```
+
+Valid states: `pending`, `done`, `abandoned`.
+
+**Response 200:** Updated `Task` (JSON).
+
+**Response 404:** `{"error": "...", "task_id": "..."}`
+
+---
+
+#### `POST /api/v1/tasks/:id/dependencies`
+
+Add a dependency between two tasks. Validates both tasks exist and prevents circular dependencies.
+
+**Query parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `channel` | `string` | `public` | Channel scope |
+
+**Request body:**
+
+```json
+{
+  "child_id": "uuid-of-child",
+  "parent_id": "uuid-of-parent",
+  "dependency_type": "blocks"
+}
+```
+
+Dependency types: `blocks`, `related`, `parent`.
+
+**Response 200:** `{"status": "ok"}`
+
+---
+
+#### `DELETE /api/v1/tasks/:id/dependencies/:dep_id`
+
+Remove a dependency.
+
+**Query parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `channel` | `string` | `public` | Channel scope |
+
+**Response 200:** `{"status": "ok"}`
+
+---
+
+#### `GET /api/v1/tasks/:id/dependencies`
+
+Get a task's direct dependencies.
+
+**Query parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `channel` | `string` | `public` | Channel scope |
+
+**Response 200:**
+
+```json
+{
+  "task_id": "...",
+  "depends_on": ["<uuid>", ...],
+  "blocking_for": ["<uuid>", ...]
+}
+```
+
+**Response 404:** `{"error": "Task not found", "task_id": "..."}`
+
+---
+
+#### `GET /api/v1/tasks/:id/graph`
+
+Get the full dependency graph for a task (all ancestors and descendants).
+
+**Query parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `channel` | `string` | `public` | Channel scope |
+
+**Response 200:**
+
+```json
+{
+  "task": { ... },
+  "parents": [...],
+  "children": [...]
+}
+```
+
+---
+
+#### `GET /api/v1/tasks/ready`
+
+Get tasks with no unresolved blockers.
+
+**Query parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `channel` | `string` | yes | Channel scope |
+
+**Response 200:** `TasksResponse` (same as list).
+
+---
+
+#### `GET /api/v1/tasks/blocked`
+
+Get tasks that are blocked by unmet dependencies.
+
+**Query parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `channel` | `string` | yes | Channel scope |
+
+**Response 200:** `TasksResponse` (same as list).
+
+---
+
+## Legacy HTTP Routes (unversioned)
+
+These routes are available but lack the `/v1/` prefix:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/channels` | List all channels with stats |
+| `GET` | `/api/channels/:channel/messages` | Message history for a channel |
+| `GET` | `/api/channels/:channel/stats` | Channel statistics |
+| `GET` | `/api/stats` | Broadcast statistics |
+
+### `GET /api/channels`
+
+**Response 200:**
+
+```json
+{
+  "channels": [
+    {
+      "name": "public",
+      "message_count": 42,
+      "oldest_message": "2026-05-02T10:00:00Z",
+      "newest_message": "2026-05-02T12:00:00Z"
+    }
+  ]
+}
+```
+
+### `GET /api/channels/:channel/messages`
+
+**Query parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `limit` | `number` | `100` | Max messages to return |
+| `offset` | `number` | `0` | (Defined but currently unused) |
+
+**Response 200:**
+
+```json
+{
+  "channel": "public",
+  "messages": [...],
+  "total_count": 42
+}
+```
+
+Max 1000 messages stored per channel (FIFO eviction).
+
+### `GET /api/channels/:channel/stats`
+
+**Response 200:**
+
+```json
+{
+  "channel": "public",
+  "message_count": 42,
+  "oldest_message": "2026-05-02T10:00:00Z",
+  "newest_message": "2026-05-02T12:00:00Z"
+}
+```
+
+### `GET /api/stats`
+
+**Response 200:**
+
+```json
+{
+  "total_viewers": 5,
+  "agent_connections": 3,
+  "viewer_connections": 2,
+  "active_channels": 2
+}
+```
+
+---
+
+## WebSocket Protocol
+
+### Connection
+
+```
+ws://{host}:{port}/
+```
+
+Default: `ws://127.0.0.1:8080/`
+
+The server accepts WebSocket upgrades on the main port. No sub-protocol negotiation required.
+
+### Channel subscription
+
+Subscription is **implicit** -- when the server receives a message on a channel, it auto-subscribes the connection to that channel. Connections receive all subsequent messages broadcast on subscribed channels.
+
+The SDK clients send explicit `subscribe`/`unsubscribe` JSON frames, but these are a client-side convention. The server-side subscription model is message-driven.
+
+### Wire format
+
+All frames are JSON text. Messages are serialized `Message` structs:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "channel": "my-channel",
+  "sender_type": "AGENT",
+  "content": { "type": "question", "text": "Ready?", "timeout_seconds": 60 },
+  "timestamp": "2026-05-02T12:00:00Z",
+  "correlation_id": null,
+  "metadata": null
+}
+```
+
+### Server processing flow
+
+1. Client sends a `Message` as a WebSocket text frame
+2. Server parses JSON into `Message` struct
+3. Server auto-subscribes the connection to `message.channel`
+4. Server stores message in per-channel history (max 1000, FIFO eviction)
+5. Server broadcasts message to all other WebSocket subscribers on that channel
+6. For interactive types (`question`, `authorization`, `navigate`):
+   - Server sends to notification sinks (Telegram)
+   - Server registers a pending prompt
+   - Server races terminal input vs. external reply (via `POST /api/v1/messages/:id/response`)
+7. Response message is broadcast to all channel subscribers
+8. Original sender matches response by `correlation_id == original_message.id`
+
+### Heartbeat
+
+No explicit heartbeat or ping protocol. Connection liveness detected by close frames and send failures.
+
+---
+
+## Data Schemas
+
+### Message
+
+```
+{
+  "id":              UUID (string),
+  "channel":         string,
+  "sender_type":     "AGENT" | "HUMAN",
+  "content":         MessageContent (discriminated by "type"),
+  "timestamp":       RFC3339 datetime string,
+  "correlation_id":  UUID | null,
+  "metadata":        object | null
+}
+```
+
+### Message content types
+
+Discriminated union on the `"type"` field:
+
+#### question
+
+```json
+{"type": "question", "text": "Ready?", "timeout_seconds": 60, "choices": ["A", "B"]}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | `string` | yes | Question text |
+| `timeout_seconds` | `number` | yes | Response timeout |
+| `choices` | `string[] \| null` | no | Multiple choice options |
+
+#### authorization
+
+```json
+{"type": "authorization", "action": "Deploy v2", "timeout_seconds": 300, "context": {}}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `action` | `string` | yes | Action description |
+| `timeout_seconds` | `number` | yes | Timeout (defaults to denied) |
+| `context` | `object \| null` | no | Additional context |
+
+#### notification
+
+```json
+{"type": "notification", "text": "Build done", "priority": "normal"}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | `string` | yes | Notification text |
+| `priority` | `string` | yes | `low`, `normal`, `high`, `urgent` |
+
+#### response
+
+```json
+{"type": "response", "answer": "Yes", "response_type": "text"}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `answer` | `string \| null` | no | Response text |
+| `response_type` | `string` | yes | See below |
+
+#### navigate
+
+```json
+{"type": "navigate", "url": "https://example.com"}
+```
+
+#### task_create
+
+```json
+{"type": "task_create", "task": { ... }}
+```
+
+#### task_update
+
+```json
+{"type": "task_update", "task_id": "uuid", "state": "done", "updated_at": "RFC3339"}
+```
+
+#### task_dependency_add
+
+```json
+{"type": "task_dependency_add", "task_id": "uuid", "depends_on": "uuid", "dependency_type": "blocks", "timestamp": "RFC3339"}
+```
+
+#### task_dependency_remove
+
+```json
+{"type": "task_dependency_remove", "task_id": "uuid", "depends_on": "uuid", "timestamp": "RFC3339"}
+```
+
+#### workflow_progress
+
+```json
+{"type": "workflow_progress", "execution_id": "uuid", "workflow_name": "deploy", "current_state": "build", "status": "running", "progress_percentage": 50}
+```
+
+#### workflow_completed
+
+```json
+{"type": "workflow_completed", "execution_id": "uuid", "workflow_name": "deploy", "final_status": "success", "duration_seconds": 120}
+```
+
+#### stdout / stderr
+
+```json
+{"type": "stdout", "execution_id": "uuid", "state_name": "build", "content": "...", "sequence": 1}
+```
+
+### Response types
+
+| Value | Description |
+|-------|-------------|
+| `text` | Text answer to a question |
+| `authorization_approved` | Authorization granted |
+| `authorization_denied` | Authorization denied |
+| `timeout` | Prompt timed out |
+| `cancelled` | User cancelled |
+
+### Task schema
+
+```
+{
+  "id":              UUID (string),
+  "title":           string,
+  "description":     string,
+  "state":           "pending" | "done" | "abandoned",
+  "created_at":      RFC3339 datetime string,
+  "updated_at":      RFC3339 datetime string,
+  "assignee":        string | null,
+  "metadata":        object | null,
+  "depends_on":      string[],
+  "blocking_for":    string[],
+  "blocked":         boolean,
+  "dependency_type": "blocks" | "related" | "parent" | null
+}
+```
+
+### Error response format
+
+```json
+{"error": "Human-readable message", "message_id": "..."}
+{"error": "Human-readable message", "task_id": "..."}
+```
+
+Validation errors return HTTP 400 with warp rejection handling. Not-found errors return HTTP 404.
+
+---
+
+## curl Examples
+
+### Send a notification
+
+```bash
+curl -X POST http://localhost:8081/api/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "channel": "public",
+    "sender_type": "AGENT",
+    "content": {"type": "notification", "text": "Build done", "priority": "normal"},
+    "timestamp": "2026-05-02T12:00:00Z"
+  }'
+```
+
+### Ask a question
+
+```bash
+curl -X POST http://localhost:8081/api/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "660e8400-e29b-41d4-a716-446655440001",
+    "channel": "public",
+    "sender_type": "AGENT",
+    "content": {"type": "question", "text": "Proceed?", "timeout_seconds": 60, "choices": ["yes", "no"]},
+    "timestamp": "2026-05-02T12:00:00Z"
+  }'
+```
+
+### Respond to a message
+
+```bash
+curl -X POST http://localhost:8081/api/v1/messages/660e8400-e29b-41d4-a716-446655440001/response \
+  -H "Content-Type: application/json" \
+  -d '{"answer": "yes", "response_type": "text"}'
+```
+
+### Check health
+
+```bash
+curl http://localhost:8081/api/v1/health
+```
+
+### Create a task
+
+```bash
+curl -X POST http://localhost:8081/api/v1/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Deploy", "description": "Deploy v2", "channel": "ops"}'
+```

--- a/skill/ailoop/references/ailoop-api.md
+++ b/skill/ailoop/references/ailoop-api.md
@@ -555,11 +555,15 @@ Discriminated union on the `"type"` field:
 
 #### workflow_progress
 
+> **Preview:** These events are emitted by the server but are not part of the supported Python/TypeScript SDK integration surface.
+
 ```json
 {"type": "workflow_progress", "execution_id": "uuid", "workflow_name": "deploy", "current_state": "build", "status": "running", "progress_percentage": 50}
 ```
 
 #### workflow_completed
+
+> **Preview:** These events are emitted by the server but are not part of the supported Python/TypeScript SDK integration surface.
 
 ```json
 {"type": "workflow_completed", "execution_id": "uuid", "workflow_name": "deploy", "final_status": "success", "duration_seconds": 120}

--- a/skill/ailoop/references/ailoop-cli.md
+++ b/skill/ailoop/references/ailoop-cli.md
@@ -1,0 +1,379 @@
+# ailoop CLI Reference
+
+The `ailoop` binary is the core CLI and server for human-in-the-loop AI agent communication.
+
+## Installation
+
+```bash
+# Homebrew (Linux)
+brew install goailoop/cli/ailoop
+
+# Scoop (Windows)
+scoop bucket add goailoop https://github.com/goailoop/scoop
+scoop install ailoop
+
+# Release binaries (Linux/Windows)
+# https://github.com/goailoop/ailoop/releases
+```
+
+Verify: `ailoop --version`
+
+## Environment Variables
+
+| Variable | Description | Default | Applies to |
+|----------|-------------|---------|------------|
+| `AILOOP_SERVER` | Server URL for remote operation. Overrides `--server` flag. Auto-converts http->ws, https->wss for WebSocket connections. | None | All remote commands |
+| `AILOOP_TELEGRAM_BOT_TOKEN` | Telegram Bot API token. Required for Telegram provider. | None | `serve`, `provider telegram test` |
+| `RUST_LOG` | Server log verbosity. Uses `tracing_subscriber` EnvFilter. | `ailoop=info` | `serve` |
+| `XDG_CONFIG_HOME` | Base config directory. Config: `$XDG_CONFIG_HOME/ailoop/config.toml`. | `~/.config` | `config`, `provider` |
+| `HOME` | Home directory. Used to resolve `~/` in config file paths. | System default | All commands |
+
+### Docker / K8s deployment variables
+
+These are set in docker-compose and K8s manifests. They are not read by the ailoop binary directly but are used as deployment patterns:
+
+| Variable | Description | Typical Value |
+|----------|-------------|---------------|
+| `AILOOP_HOST` | Bind host for container | `0.0.0.0` |
+| `AILOOP_PORT` | Server port for container | `8080` |
+| `AILOOP_BASE_URL` | URL for SDK clients to reach the sidecar | `http://ailoop-sidecar:8081` |
+
+## Global Options
+
+| Flag | Description |
+|------|-------------|
+| `-h`, `--help` | Print help |
+| `-V`, `--version` | Print version |
+
+Common flags on most commands:
+
+| Flag | Description |
+|------|-------------|
+| `-c`, `--channel <CHANNEL>` | Channel name (default: `public`) |
+| `--server <SERVER>` | Remote server URL (default: empty = local) |
+| `--json` | Output in JSON format |
+
+## ask -- Ask a question
+
+Ask a question and wait for a human response. Blocks until answered.
+
+```bash
+ailoop ask "What is the best approach?"
+ailoop ask "Choose a color|red|blue|green"
+ailoop ask "Should we proceed?" --timeout 60 --channel dev-review --json
+```
+
+**Multiple choice format:** Use pipe separator: `"question|choice1|choice2|choice3"`
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-c`, `--channel` | `public` | Target channel |
+| `-t`, `--timeout` | `0` (none) | Timeout in seconds, 0 = no timeout |
+| `--server` | empty | Server URL for remote operation |
+| `--json` | off | JSON output |
+
+**JSON response format (text):**
+```json
+{"response": "answer text", "channel": "public", "timestamp": "..."}
+```
+
+**JSON response format (multiple choice):**
+```json
+{
+  "response": "red",
+  "channel": "public",
+  "timestamp": "...",
+  "metadata": {"index": 0, "value": "red"}
+}
+```
+
+## authorize -- Request authorization
+
+Request human approval. Defaults to **DENIED** on timeout, Ctrl+C, or read errors.
+
+```bash
+ailoop authorize "Deploy version 1.2.3 to production"
+ailoop authorize "Delete user data" --timeout 300 --channel admin-ops
+ailoop authorize "Restart service?" --default no
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-c`, `--channel` | `public` | Target channel |
+| `-t`, `--timeout` | `300` | Timeout in seconds |
+| `--server` | empty | Server URL for remote operation |
+| `--json` | off | JSON output |
+| `--default` | `yes` | Decision when Enter is pressed (`yes` or `no`) |
+
+Press Enter to accept the configured default. Timeout, read errors, and Ctrl+C always resolve to denied for security.
+
+## say -- Send a notification
+
+Non-blocking. Sends a one-way notification.
+
+```bash
+ailoop say "Build completed successfully"
+ailoop say "System alert: High CPU" --priority high --channel monitoring
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-c`, `--channel` | `public` | Target channel |
+| `-p`, `--priority` | `normal` | `low`, `normal`, `high`, `urgent` |
+| `--server` | empty | Server URL for remote operation |
+
+## image -- Display an image
+
+Display an image to the user.
+
+```bash
+ailoop image ./screenshot.png
+ailoop image https://example.com/diagram.png --channel design
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-c`, `--channel` | `public` | Target channel |
+| `--server` | empty | Server URL for remote operation |
+
+## navigate -- Suggest URL navigation
+
+Suggest the user navigate to a URL.
+
+```bash
+ailoop navigate https://dashboard.example.com/deploy/123
+ailoop navigate https://docs.example.com --channel onboarding
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-c`, `--channel` | `public` | Target channel |
+| `--server` | empty | Server URL for remote operation |
+
+## serve -- Run server mode
+
+Start the ailoop server for multi-agent communication. Provides both HTTP REST API and WebSocket endpoint.
+
+```bash
+ailoop serve
+ailoop serve --port 9000 --host 0.0.0.0
+ailoop serve --channel default-channel
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `127.0.0.1` | Bind address |
+| `-p`, `--port` | `8080` | Server port |
+| `-c`, `--channel` | `public` | Default channel |
+
+The server exposes:
+- HTTP API at `http://{host}:{port}/api/v1/...`
+- WebSocket at `ws://{host}:{port}/ws`
+
+## forward -- Stream agent output
+
+Stream agent output to the server. Reads from stdin by default.
+
+```bash
+# Pipe agent output to server
+agent -p --output-format stream-json "prompt" 2>&1 | ailoop forward --channel public --agent-type cursor
+
+# From file
+ailoop forward --input output.jsonl --channel my-agent
+
+# Save to file instead of WebSocket
+ailoop forward --transport file --output /tmp/ailoop-messages.jsonl
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-c`, `--channel` | `public` | Channel for messages |
+| `--agent-type` | auto | `cursor`, `jsonl`, `opencode`, or auto-detect |
+| `--format` | `stream-json` | `json`, `stream-json`, `text` |
+| `--transport` | `websocket` | `websocket` or `file` |
+| `--url` | `ws://127.0.0.1:8080` | WebSocket URL |
+| `--output` | none | Output file (for file transport) |
+| `--input` | stdin | Input file path |
+| `--client-id` | none | Client ID for tracking |
+
+**Cursor CLI example:**
+1. Start server: `ailoop serve`
+2. In another terminal: `agent -p --output-format stream-json "Your prompt" 2>&1 | ailoop forward --channel public --agent-type cursor`
+
+## task -- Task management
+
+Manage tasks with states and dependency tracking.
+
+### task create
+
+```bash
+ailoop task create "Deploy service" --description "Deploy v2 to staging" --channel ops
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-d`, `--description` | required | Task description |
+| `-c`, `--channel` | `public` | Target channel |
+| `--server` | empty | Server URL |
+| `--json` | off | JSON output |
+
+### task list
+
+```bash
+ailoop task list --channel ops --state pending --json
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-c`, `--channel` | `public` | Channel filter |
+| `--state` | none | Filter by state (`pending`, `done`, `abandoned`) |
+| `--server` | empty | Server URL |
+| `--json` | off | JSON output |
+
+### task show
+
+```bash
+ailoop task show <TASK_ID> --json
+```
+
+### task update
+
+```bash
+ailoop task update <TASK_ID> --state done --channel ops
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-s`, `--state` | required | New state (`pending`, `done`, `abandoned`) |
+| `-c`, `--channel` | `public` | Target channel |
+| `--server` | empty | Server URL |
+| `--json` | off | JSON output |
+
+### task dep -- Dependency management
+
+```bash
+# Add dependency
+ailoop task dep add <CHILD_ID> <PARENT_ID> --type blocks
+
+# Remove dependency
+ailoop task dep remove <CHILD_ID> <PARENT_ID>
+
+# Show dependency graph
+ailoop task dep graph <TASK_ID>
+```
+
+Dependency types: `blocks`, `related`, `parent`.
+
+### task ready / task blocked
+
+```bash
+ailoop task ready --channel ops --json
+ailoop task blocked --channel ops --json
+```
+
+## workflow -- Workflow orchestration
+
+Manage workflow definitions and executions.
+
+### workflow start
+
+```bash
+ailoop workflow start <WORKFLOW_NAME> --initiator cli-user
+```
+
+### workflow status
+
+```bash
+ailoop workflow status <EXECUTION_ID> --json
+```
+
+### workflow list / list-defs
+
+```bash
+ailoop workflow list          # List running executions
+ailoop workflow list-defs     # List available workflow YAML files
+```
+
+### workflow approve / deny
+
+```bash
+ailoop workflow approve <APPROVAL_ID> --operator alice
+ailoop workflow deny <APPROVAL_ID> --operator alice
+```
+
+### workflow list-approvals
+
+```bash
+ailoop workflow list-approvals --execution <EXECUTION_ID> --json
+```
+
+### workflow logs
+
+```bash
+ailoop workflow logs <EXECUTION_ID> --limit 50 --follow
+ailoop workflow logs <EXECUTION_ID> --state deploy
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-s`, `--state` | all | Filter by state name |
+| `-l`, `--limit` | `100` | Number of recent lines |
+| `--offset` | `0` | Skip first N lines |
+| `-f`, `--follow` | off | Follow output in real-time |
+| `--json` | off | JSON output |
+
+### workflow metrics
+
+```bash
+ailoop workflow metrics --workflow deploy-pipeline --json
+```
+
+### workflow validate
+
+```bash
+ailoop workflow validate path/to/workflow.yaml
+```
+
+### workflow history
+
+```bash
+ailoop workflow history
+```
+
+## config -- Interactive configuration
+
+```bash
+ailoop config --init
+ailoop config --init --config-file /path/to/config.toml
+```
+
+Default config location: `~/.config/ailoop/config.toml`
+
+## provider -- Provider management
+
+```bash
+ailoop provider list              # List configured providers
+ailoop provider telegram test     # Test Telegram integration
+```
+
+## Channel Rules
+
+Channels isolate workflows. Names: 1-64 chars, lowercase alphanumeric, hyphens, underscores; must start with letter or digit. Default channel is `public`.
+
+## Telegram Provider Setup
+
+1. Create bot via [@BotFather](https://t.me/BotFather), copy token.
+2. Start a chat with your bot (search username, open chat, tap Start or send `/start`).
+3. Get chat ID (e.g. [@userinfobot](https://t.me/userinfobot) or group ID).
+4. Set token: `export AILOOP_TELEGRAM_BOT_TOKEN=your_bot_token`
+5. Configure: `ailoop config --init` and enable Telegram with `chat_id`.
+6. Test: `ailoop provider telegram test`
+7. Run server: `ailoop serve` -- questions/authorizations answered in Telegram or terminal.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Connection refused on forward | Ensure `ailoop serve` is running (default WS port 8080). Use `--url ws://HOST:PORT`. |
+| No messages visible on server | Run `ailoop serve` in an external terminal (real TTY), not IDE integrated terminal. |
+| Testing WebSocket delivery | Use [websocat](https://github.com/vi/websocat) to replay captured messages. |

--- a/skill/ailoop/references/ailoop-cli.md
+++ b/skill/ailoop/references/ailoop-cli.md
@@ -273,6 +273,8 @@ ailoop task blocked --channel ops --json
 
 ## workflow -- Workflow orchestration
 
+> **Preview:** Workflow orchestration is not yet supported in ailoop-py or ailoop-js SDK integrations.
+
 Manage workflow definitions and executions.
 
 ### workflow start

--- a/skill/ailoop/references/ailoop-js.md
+++ b/skill/ailoop/references/ailoop-js.md
@@ -1,0 +1,362 @@
+# ailoop-js Reference
+
+TypeScript/JavaScript SDK for ailoop server communication. Client-only -- requires a running `ailoop serve` instance.
+
+## Installation
+
+```bash
+npm install ailoop-js
+```
+
+Dependencies: `axios ^1.6`, `isomorphic-ws ^5.0`, `ws ^8.14`. Requires Node.js >= 16.
+
+## Setup
+
+```typescript
+import { AiloopClient } from 'ailoop-js';
+
+const client = new AiloopClient({
+  baseURL: 'http://localhost:8080',
+  timeout: 30000,
+  maxRetries: 5,
+  retryDelay: 1000,
+});
+```
+
+### AiloopClientOptions
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `baseURL` | `string` | `'http://localhost:8080'` | Server base URL |
+| `timeout` | `number` | `30000` | HTTP request timeout (ms) |
+| `maxRetries` | `number` | `5` | Max WebSocket reconnection attempts |
+| `retryDelay` | `number` | `1000` | Base reconnection delay (ms), exponential backoff |
+
+## Sending Messages
+
+All send methods POST to `/api/v1/messages` and return `Promise<Message>`.
+
+### ask -- Ask a question
+
+```typescript
+const msg = await client.ask(
+  'general',
+  'What approach should we use?',
+  60,
+  ['Option A', 'Option B', 'Option C']
+);
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `channel` | `string` | required | Target channel |
+| `question` | `string` | required | Question text |
+| `timeoutSeconds?` | `number` | `60` | Response timeout in seconds |
+| `choices?` | `string[]` | `undefined` | Multiple choice options |
+
+### authorize -- Request authorization
+
+```typescript
+const msg = await client.authorize(
+  'admin-ops',
+  'Deploy v2.0 to production',
+  300,
+  { version: '2.0', environment: 'prod' }
+);
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `channel` | `string` | required | Target channel |
+| `action` | `string` | required | Action description |
+| `timeoutSeconds?` | `number` | `300` | Timeout (denied on expiry) |
+| `context?` | `Record<string, any>` | `undefined` | Additional metadata |
+
+### say -- Send a notification
+
+```typescript
+const msg = await client.say('monitoring', 'Build completed', 'high');
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `channel` | `string` | required | Target channel |
+| `text` | `string` | required | Notification text |
+| `priority?` | `NotificationPriority` | `'normal'` | `'low'`, `'normal'`, `'high'`, `'urgent'` |
+
+### navigate -- Send a navigation URL
+
+```typescript
+const msg = await client.navigate('public', 'https://dashboard.example.com');
+```
+
+### respond -- Reply to a message
+
+Fetches the original message to determine channel, then sends response with `correlation_id`.
+
+```typescript
+const response = await client.respond(
+  '550e8400-e29b-41d4-a716-446655440000',
+  'Yes, proceed',
+  'text'
+);
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `messageId` | `string` | required | Original message ID |
+| `answer?` | `string` | `undefined` | Response text |
+| `responseType?` | `ResponseType` | `'text'` | `'text'`, `'authorization_approved'`, `'authorization_denied'`, `'timeout'`, `'cancelled'` |
+
+### getMessage -- Retrieve a message
+
+```typescript
+const msg = await client.getMessage('550e8400-e29b-41d4-a716-446655440000');
+```
+
+## Listening for Messages (WebSocket)
+
+### Connect and register handlers
+
+```typescript
+import { AiloopClient, WebSocketMessage } from 'ailoop-js';
+
+const client = new AiloopClient({ baseURL: 'http://localhost:8080' });
+
+client.addMessageHandler((message: WebSocketMessage) => {
+  if (message.type === 'message' && message.data) {
+    const content = message.data.content;
+    switch (content.type) {
+      case 'question':
+        console.log(`Question: ${content.text}`);
+        break;
+      case 'authorization':
+        console.log(`Auth request: ${content.action}`);
+        break;
+      case 'notification':
+        console.log(`Notification: ${content.text}`);
+        break;
+      case 'response':
+        console.log(`Response: ${content.answer}`);
+        break;
+    }
+  }
+});
+
+client.addConnectionHandler((event) => {
+  console.log(`Connection: ${event.type}`);
+});
+
+await client.connect();               // version check + WebSocket
+await client.subscribe('public');
+
+// Keep process alive
+await new Promise(() => {});
+```
+
+### Channel subscriptions
+
+```typescript
+await client.subscribe('dev-review');
+await client.unsubscribe('dev-review');
+```
+
+Subscriptions are automatically re-established on reconnection.
+
+### Reconnection
+
+Automatic exponential backoff: `delay = 1000ms * 2^(attempt-1)`. Max 5 attempts. Configured by `maxRetries` and `retryDelay` constructor options.
+
+### Connection state
+
+```typescript
+const state = client.getConnectionState();
+// { connected: boolean, url?: string, channels: string[] }
+```
+
+### Disconnect
+
+```typescript
+await client.disconnect();
+```
+
+Sets `manualDisconnect` flag, clears reconnect timers, closes WebSocket, fires `'disconnected'` to handlers.
+
+### Important limitations
+
+- `ask()` and `authorize()` return the **sent** message, not the human's reply. Use `addMessageHandler()` and match on `correlation_id` to get responses.
+- Handlers receive `WebSocketMessage` objects. There is no typed event dispatch.
+- No `removeMessageHandler()` or `removeConnectionHandler()` -- create a new client to clear handlers.
+
+## Task Management
+
+### Create a task
+
+```typescript
+const task = await client.createTask(
+  'ops',
+  'Deploy service',
+  'Deploy v2 to staging',
+  'alice',
+  { priority: 'high' }
+);
+```
+
+### Update task state
+
+```typescript
+const task = await client.updateTask('ops', 'task-id-123', 'done');
+```
+
+Valid states: `'pending'`, `'done'`, `'abandoned'`.
+
+### List / get tasks
+
+```typescript
+const tasks = await client.listTasks('ops', 'pending');
+const task = await client.getTask('task-id-123');
+```
+
+### Dependencies
+
+```typescript
+await client.addDependency('child-id', 'parent-id', 'blocks');
+await client.removeDependency('child-id', 'parent-id');
+```
+
+Dependency types: `'blocks'`, `'related'`, `'parent'`.
+
+### Query dependency state
+
+```typescript
+const ready = await client.getReadyTasks('ops');
+const blocked = await client.getBlockedTasks('ops');
+const graph = await client.getDependencyGraph('task-id-123');
+// graph: { task: Task; parents: Task[]; children: Task[] }
+```
+
+## Health & Version
+
+```typescript
+const health = await client.checkHealth();
+// { status, version, activeConnections, queueSize, activeChannels }
+
+const versionInfo = await client.checkVersion();
+// { clientVersion, serverVersion, compatible, warnings[], errors[] }
+
+await client.ensureVersionCompatibility(); // throws ValidationError if incompatible
+```
+
+## MessageFactory
+
+Static factory for creating partial message objects (without `id` and `timestamp`, which are server-assigned):
+
+```typescript
+import { MessageFactory } from 'ailoop-js';
+
+const q = MessageFactory.createQuestion('general', 'Ready?', 60, ['yes', 'no']);
+const a = MessageFactory.createAuthorization('admin', 'Deploy', 300);
+const n = MessageFactory.createNotification('general', 'Done', 'normal');
+const r = MessageFactory.createResponse(correlationId, 'yes', 'text');
+const nav = MessageFactory.createNavigate('general', 'https://example.com');
+```
+
+## Types
+
+### Message
+
+```typescript
+interface Message {
+  id: string;
+  channel: string;
+  sender_type: SenderType;
+  content: MessageContent;
+  timestamp: string;
+  correlation_id?: string;
+  metadata?: Record<string, any>;
+}
+```
+
+### Content types (discriminated union on `type`)
+
+| Type | Key fields |
+|------|------------|
+| `question` | `text`, `timeout_seconds`, `choices?` |
+| `authorization` | `action`, `timeout_seconds`, `context?` |
+| `notification` | `text`, `priority` |
+| `response` | `answer?`, `response_type` |
+| `navigate` | `url` |
+
+### Type aliases
+
+| Name | Values |
+|------|--------|
+| `SenderType` | `'HUMAN'`, `'AGENT'`, `'SYSTEM'` |
+| `ResponseType` | `'text'`, `'authorization_approved'`, `'authorization_denied'`, `'timeout'`, `'cancelled'` |
+| `NotificationPriority` | `'low'`, `'normal'`, `'high'`, `'urgent'` |
+| `TaskState` | `'pending'`, `'done'`, `'abandoned'` |
+| `DependencyType` | `'blocks'`, `'related'`, `'parent'` |
+
+### Handler types
+
+```typescript
+type MessageHandler = (message: WebSocketMessage) => void | Promise<void>;
+type ConnectionHandler = (event: { type: 'connected' | 'disconnected' | 'error'; error?: string }) => void | Promise<void>;
+```
+
+### WebSocketMessage
+
+```typescript
+interface WebSocketMessage {
+  type: 'message' | 'subscribe' | 'unsubscribe' | 'connected' | 'disconnected' | 'error';
+  channel?: string;
+  data?: any;
+  error?: string;
+}
+```
+
+### Task
+
+```typescript
+interface Task {
+  id: string;
+  title: string;
+  description: string;
+  state: TaskState;
+  created_at: string;
+  updated_at: string;
+  assignee?: string;
+  metadata?: Record<string, any>;
+  depends_on: string[];
+  blocking_for: string[];
+  blocked: boolean;
+  dependency_type?: DependencyType;
+}
+```
+
+## Error Classes
+
+All inherit from `AiloopError` which extends `Error`:
+
+| Class | `code` | When thrown |
+|-------|--------|-------------|
+| `ConnectionError` | `'CONNECTION_ERROR'` | HTTP/network failures, WebSocket failures |
+| `ValidationError` | `'VALIDATION_ERROR'` | Invalid input, 400 responses, 404 not-found |
+| `TimeoutError` | `'TIMEOUT_ERROR'` | Request timeout |
+
+## REST API Endpoints
+
+| Endpoint | Method | Client method(s) |
+|----------|--------|-------------------|
+| `/api/v1/messages` | POST | `ask`, `authorize`, `say`, `navigate` |
+| `/api/v1/messages/{id}` | GET | `getMessage`, `respond` |
+| `/api/v1/tasks` | POST | `createTask` |
+| `/api/v1/tasks` | GET | `listTasks` |
+| `/api/v1/tasks/{id}` | GET/PUT | `getTask`, `updateTask` |
+| `/api/v1/tasks/{id}/dependencies` | POST | `addDependency` |
+| `/api/v1/tasks/{id}/dependencies/{id}` | DELETE | `removeDependency` |
+| `/api/v1/tasks/ready` | GET | `getReadyTasks` |
+| `/api/v1/tasks/blocked` | GET | `getBlockedTasks` |
+| `/api/v1/tasks/{id}/graph` | GET | `getDependencyGraph` |
+| `/api/v1/health` | GET | `checkHealth`, `checkVersion` |
+| `ws://{host}/ws` | WebSocket | `connect`, `subscribe`, `unsubscribe` |

--- a/skill/ailoop/references/ailoop-py.md
+++ b/skill/ailoop/references/ailoop-py.md
@@ -1,0 +1,315 @@
+# ailoop-py Reference
+
+Python SDK for ailoop server communication. Client-only -- requires a running `ailoop serve` instance.
+
+## Installation
+
+```bash
+pip install ailoop-py
+```
+
+Dependencies: `httpx>=0.24`, `websockets>=11`, `pydantic>=2`, `typing-extensions>=4.5`. Requires Python >= 3.11.
+
+## Setup
+
+```python
+from ailoop import AiloopClient
+
+client = AiloopClient(
+    server_url="http://localhost:8080",
+    channel="public",
+    timeout=30.0,
+    reconnect_attempts=5,
+    reconnect_delay=1.0,
+)
+```
+
+### Async context manager (recommended)
+
+Manages HTTP client lifecycle and WebSocket connection automatically:
+
+```python
+async with AiloopClient(server_url="http://localhost:8080") as client:
+    msg = await client.ask("Ready to proceed?")
+    await client.say("Done")
+```
+
+### Manual lifecycle
+
+```python
+client = AiloopClient(server_url="http://localhost:8080")
+await client.connect()           # HTTP client + health check
+await client.connect_websocket() # WebSocket loop in background
+# ... use client ...
+await client.disconnect_websocket()
+await client.disconnect()
+```
+
+## Sending Messages
+
+All send methods POST to `/api/v1/messages` and return the server-created `Message`.
+
+### ask -- Ask a question
+
+```python
+msg = await client.ask(
+    question="What approach?",
+    channel="dev-review",
+    timeout=60,
+    choices=["Option A", "Option B", "Option C"],
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `question` | `str` | required | Question text |
+| `channel` | `str \| None` | client default | Target channel |
+| `timeout` | `int \| None` | `60` | Response timeout in seconds |
+| `choices` | `list[str] \| None` | `None` | Multiple choice options |
+
+### authorize -- Request authorization
+
+```python
+msg = await client.authorize(
+    action="Deploy v2.0 to production",
+    channel="admin-ops",
+    timeout=300,
+    context={"version": "2.0", "environment": "prod"},
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `action` | `str` | required | Action description |
+| `channel` | `str \| None` | client default | Target channel |
+| `timeout` | `int \| None` | `300` | Timeout in seconds (denied on expiry) |
+| `context` | `dict \| None` | `None` | Additional metadata |
+
+### say -- Send a notification
+
+```python
+msg = await client.say(
+    message="Build completed",
+    channel="monitoring",
+    priority="high",
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `message` | `str` | required | Notification text |
+| `channel` | `str \| None` | client default | Target channel |
+| `priority` | `NotificationPriority` | `NORMAL` | `LOW`, `NORMAL`, `HIGH`, `URGENT` |
+
+### navigate -- Send a navigation URL
+
+```python
+msg = await client.navigate(
+    url="https://dashboard.example.com/deploy/123",
+    channel="public",
+)
+```
+
+### respond -- Reply to a message
+
+Fetches the original message to determine its channel, then sends a response with `correlation_id` set.
+
+```python
+response = await client.respond(
+    original_message_id="550e8400-e29b-41d4-a716-446655440000",
+    answer="Yes, proceed",
+    response_type="text",
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `original_message_id` | `str \| UUID` | required | ID of the message to respond to |
+| `answer` | `str \| None` | `None` | Response text |
+| `response_type` | `ResponseType` | `TEXT` | `TEXT`, `AUTHORIZATION_APPROVED`, `AUTHORIZATION_DENIED`, `TIMEOUT`, `CANCELLED` |
+
+### get_message -- Retrieve a message
+
+```python
+msg = await client.get_message("550e8400-e29b-41d4-a716-446655440000")
+```
+
+## Listening for Messages (WebSocket)
+
+The SDK provides real-time message reception via WebSocket with handler callbacks.
+
+### Connect and register handlers
+
+```python
+from ailoop import AiloopClient
+
+client = AiloopClient(server_url="http://localhost:8080")
+
+async def on_message(data: dict):
+    content = data.get("content", {})
+    msg_type = content.get("type")
+
+    if msg_type == "question":
+        print(f"Question: {content['text']}")
+    elif msg_type == "authorization":
+        print(f"Auth request: {content['action']}")
+    elif msg_type == "notification":
+        print(f"Notification: {content['text']}")
+    elif msg_type == "response":
+        print(f"Response: {content.get('answer')}")
+    else:
+        print(f"Message: {data}")
+
+async def on_connection(event: dict):
+    print(f"Connection event: {event['type']}")
+
+client.add_message_handler(on_message)
+client.add_connection_handler(on_connection)
+
+await client.connect()
+await client.connect_websocket()
+await client.subscribe_to_channel("public")
+
+try:
+    await asyncio.Future()  # run forever
+finally:
+    await client.disconnect_websocket()
+    await client.disconnect()
+```
+
+### Channel subscriptions
+
+```python
+await client.subscribe_to_channel("dev-review")
+await client.unsubscribe_from_channel("dev-review")
+```
+
+Subscriptions are automatically re-established on reconnection.
+
+### Reconnection
+
+The WebSocket loop reconnects automatically with exponential backoff. Configured by:
+- `reconnect_attempts` (default 5): max reconnection tries
+- `reconnect_delay` (default 1.0s): base delay, doubled each attempt
+
+### Important limitations
+
+- `ask()` and `authorize()` return the **sent** message, not the human's reply. To receive responses, register a handler via `add_message_handler()` and match on `correlation_id`.
+- Handlers receive raw JSON `dict` objects. There is no typed event dispatch or filtering built in.
+- There is no `remove_message_handler()` -- create a new client to clear handlers.
+
+## Task Management
+
+### Create a task
+
+```python
+task = await client.create_task(
+    title="Deploy service",
+    description="Deploy v2 to staging",
+    channel="ops",
+    assignee="alice",
+    metadata={"priority": "high"},
+)
+```
+
+### Update task state
+
+```python
+task = await client.update_task(task_id="abc-123", state="done")
+```
+
+Valid states: `pending`, `done`, `abandoned`.
+
+### List / get tasks
+
+```python
+tasks = await client.list_tasks(channel="ops", state="pending")
+task = await client.get_task(task_id="abc-123")
+```
+
+### Dependencies
+
+```python
+await client.add_dependency(task_id="child-id", depends_on="parent-id", type="blocks")
+await client.remove_dependency(task_id="child-id", depends_on="parent-id")
+```
+
+Dependency types: `blocks`, `related`, `parent`.
+
+### Query dependency state
+
+```python
+ready = await client.get_ready_tasks(channel="ops")
+blocked = await client.get_blocked_tasks(channel="ops")
+graph = await client.get_dependency_graph(task_id="abc-123")
+# graph = {"task": ..., "parents": [...], "children": [...]}
+```
+
+## Health & Version
+
+```python
+info = await client.check_version_compatibility()
+# {"server_version": "0.1.7", "client_version": "0.1.1", "compatible": true/false}
+```
+
+## Models
+
+### Message
+
+Core envelope. Created via factory methods or received from server.
+
+```python
+Message.create_question(channel, text, timeout_seconds=60, choices=None)
+Message.create_authorization(channel, action, timeout_seconds=300, context=None)
+Message.create_notification(channel, text, priority=NotificationPriority.NORMAL)
+Message.create_response(channel, correlation_id, answer=None, response_type=ResponseType.TEXT)
+```
+
+Fields: `id` (UUID), `channel`, `sender_type`, `content`, `timestamp`, `correlation_id`, `metadata`.
+
+### Content types (discriminated union on `type` field)
+
+| Type | Content class | Key fields |
+|------|---------------|------------|
+| `question` | `QuestionContent` | `text`, `timeout_seconds`, `choices` |
+| `authorization` | `AuthorizationContent` | `action`, `timeout_seconds`, `context` |
+| `notification` | `NotificationContent` | `text`, `priority` |
+| `response` | `ResponseContent` | `answer`, `response_type` |
+| `navigate` | `NavigateContent` | `url` |
+
+### Enums
+
+| Enum | Values |
+|------|--------|
+| `SenderType` | `AGENT`, `HUMAN` |
+| `ResponseType` | `TEXT`, `AUTHORIZATION_APPROVED`, `AUTHORIZATION_DENIED`, `TIMEOUT`, `CANCELLED` |
+| `NotificationPriority` | `LOW`, `NORMAL`, `HIGH`, `URGENT` |
+| `TaskState` | `PENDING`, `DONE`, `ABANDONED` |
+| `DependencyType` | `BLOCKS`, `RELATED`, `PARENT` |
+
+## Exceptions
+
+All inherit from `AiloopError`:
+
+| Exception | When raised |
+|-----------|-------------|
+| `ConnectionError` | HTTP failures, WebSocket failures, server unreachable |
+| `ValidationError` | Invalid input, 400 responses, 404 not-found |
+| `TimeoutError` | Request timeout |
+
+## REST API Endpoints
+
+| Endpoint | Method | Client method(s) |
+|----------|--------|-------------------|
+| `/api/v1/messages` | POST | `ask`, `authorize`, `say`, `navigate` |
+| `/api/v1/messages/{id}` | GET | `get_message`, `respond` |
+| `/api/v1/tasks` | POST | `create_task` |
+| `/api/v1/tasks` | GET | `list_tasks` |
+| `/api/v1/tasks/{id}` | GET/PUT | `get_task`, `update_task` |
+| `/api/v1/tasks/{id}/dependencies` | POST | `add_dependency` |
+| `/api/v1/tasks/{id}/dependencies/{id}` | DELETE | `remove_dependency` |
+| `/api/v1/tasks/ready` | GET | `get_ready_tasks` |
+| `/api/v1/tasks/blocked` | GET | `get_blocked_tasks` |
+| `/api/v1/tasks/{id}/graph` | GET | `get_dependency_graph` |
+| `/api/v1/health` | GET | `check_version_compatibility` |
+| `ws://{host}/ws` | WebSocket | `connect_websocket` |

--- a/skill/ailoop/references/ailoop-py.md
+++ b/skill/ailoop/references/ailoop-py.md
@@ -138,43 +138,118 @@ msg = await client.get_message("550e8400-e29b-41d4-a716-446655440000")
 
 The SDK provides real-time message reception via WebSocket with handler callbacks.
 
-### Connect and register handlers
+### Handler registration order
+
+**`add_message_handler()` and `add_connection_handler()` MUST be called before entering the `async with` block** (or before calling `connect_websocket()` manually).
+
+`__aenter__` immediately calls `connect_websocket()`, which spawns a background `asyncio.Task` (`_websocket_loop`) that begins dispatching inbound messages and connection events. Any handler registered after `__aenter__` starts can silently miss messages — including the initial `{"type": "connected"}` connection event — that arrived between the task spawn and the registration call.
+
+Both methods are synchronous list-appends and are safe to call at any point before the context manager is entered:
+
+```python
+client = AiloopClient("http://localhost:8080")
+client.add_message_handler(on_message)       # MUST precede async with
+client.add_connection_handler(on_connection) # MUST precede async with
+
+async with client:
+    ...
+```
+
+### What `async with` does
+
+**`__aenter__`** (in order):
+1. `connect()` — initialises `httpx.AsyncClient`, calls `check_version_compatibility()`. Raises `ConnectionError` if the server is unreachable.
+2. `connect_websocket()` — spawns `_websocket_loop` as a background `asyncio.Task` that opens the WebSocket and starts dispatching messages to registered handlers.
+
+**`__aexit__`** (always, even on exception):
+1. `disconnect_websocket()` — cancels the background task and awaits its completion, closes the WebSocket.
+2. `disconnect()` — closes the `httpx.AsyncClient` (also tears down the WebSocket task if somehow still running).
+
+### Manual lifecycle
+
+Use manual lifecycle when you cannot use the context manager (e.g., class-level client):
+
+```python
+client = AiloopClient(server_url="http://localhost:8080")
+client.add_message_handler(on_message)
+
+await client.connect()            # 1. HTTP client init + version check
+await client.connect_websocket()  # 2. Spawns background receive loop
+await client.subscribe_to_channel("public")  # 3. Subscribe (requires ws open)
+
+# ... do work ...
+
+await client.disconnect_websocket()  # 4. Cancel background task
+await client.disconnect()            # 5. Close HTTP client
+```
+
+Calling `disconnect()` alone also tears down the WebSocket task if still running.
+
+### Correlation ID and reply matching
+
+`ask()` and `authorize()` POST to `/api/v1/messages` and return the **sent** `Message` object. They do **not** await the human reply.
+
+To correlate a human `response` event received via WebSocket to a specific `ask`/`authorize` call, match `data["correlation_id"]` against `str(sent_message.id)`. Using a `dict[str, asyncio.Future]` keyed by correlation ID supports multiple concurrent requests:
+
+```python
+pending: dict[str, asyncio.Future] = {}
+
+async def on_message(data: dict) -> None:
+    cid = data.get("correlation_id")
+    if cid and cid in pending:
+        pending[cid].set_result(data)
+
+# Before async with:
+client.add_message_handler(on_message)
+
+async with client:
+    await client.subscribe_to_channel("public")
+    sent = await client.ask("Proceed?", timeout=60)
+    fut: asyncio.Future = asyncio.get_event_loop().create_future()
+    pending[str(sent.id)] = fut
+    reply = await fut
+    print(reply["content"].get("answer"))
+```
+
+### Complete runnable example
+
+See [`ailoop-py/examples/streaming_agent.py`](../../../../ailoop-py/examples/streaming_agent.py) for a full example covering handlers, `async with`, channel subscription, `ask`, correlated reply, and clean `asyncio.Event`-based shutdown.
 
 ```python
 from ailoop import AiloopClient
+import asyncio
 
-client = AiloopClient(server_url="http://localhost:8080")
+async def main() -> None:
+    pending: dict[str, asyncio.Future] = {}
+    stop = asyncio.Event()
 
-async def on_message(data: dict):
-    content = data.get("content", {})
-    msg_type = content.get("type")
+    async def on_message(data: dict) -> None:
+        content = data.get("content", {})
+        cid = data.get("correlation_id")
+        if content.get("type") == "response" and cid and cid in pending:
+            pending[cid].set_result(data)
+            stop.set()
+        else:
+            print(f"[message] type={content.get('type')} channel={data.get('channel')}")
 
-    if msg_type == "question":
-        print(f"Question: {content['text']}")
-    elif msg_type == "authorization":
-        print(f"Auth request: {content['action']}")
-    elif msg_type == "notification":
-        print(f"Notification: {content['text']}")
-    elif msg_type == "response":
-        print(f"Response: {content.get('answer')}")
-    else:
-        print(f"Message: {data}")
+    async def on_connection(event: dict) -> None:
+        print(f"[connection] {event['type']}")
 
-async def on_connection(event: dict):
-    print(f"Connection event: {event['type']}")
+    client = AiloopClient("http://127.0.0.1:8080", channel="public")
+    client.add_message_handler(on_message)       # MUST be before async with
+    client.add_connection_handler(on_connection)
 
-client.add_message_handler(on_message)
-client.add_connection_handler(on_connection)
+    async with client:
+        await client.subscribe_to_channel("public")
+        sent = await client.ask("Proceed with deployment?", timeout=120)
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        pending[str(sent.id)] = fut
+        await stop.wait()
+        reply = fut.result()
+        print(f"[reply] {reply['content'].get('answer')}")
 
-await client.connect()
-await client.connect_websocket()
-await client.subscribe_to_channel("public")
-
-try:
-    await asyncio.Future()  # run forever
-finally:
-    await client.disconnect_websocket()
-    await client.disconnect()
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ### Channel subscriptions
@@ -192,11 +267,22 @@ The WebSocket loop reconnects automatically with exponential backoff. Configured
 - `reconnect_attempts` (default 5): max reconnection tries
 - `reconnect_delay` (default 1.0s): base delay, doubled each attempt
 
+After `reconnect_attempts` consecutive failures the background task exits silently (no exception is raised). Monitor connection health by checking `{"type": "connected"}` events in an `add_connection_handler()` callback — the absence of a reconnect event is the signal that the loop has stopped.
+
 ### Important limitations
 
-- `ask()` and `authorize()` return the **sent** message, not the human's reply. To receive responses, register a handler via `add_message_handler()` and match on `correlation_id`.
+- `ask()` and `authorize()` return the **sent** message, not the human's reply. To receive responses, register a handler via `add_message_handler()` and match on `correlation_id`. See [Correlation ID and reply matching](#correlation-id-and-reply-matching) above.
 - Handlers receive raw JSON `dict` objects. There is no typed event dispatch or filtering built in.
 - There is no `remove_message_handler()` -- create a new client to clear handlers.
+
+### Workflow orchestration (out of scope / preview)
+
+CLI `workflow` subcommands, and `workflow_progress` / `workflow_completed` WebSocket event types are **not supported for Python SDK integrators** and are not covered in these docs or examples.
+
+- For CLI workflow commands, see [`ailoop-cli.md`](ailoop-cli.md).
+- For the WebSocket event schema, see [`ailoop-api.md`](ailoop-api.md).
+
+Do not generate Python SDK code that targets workflow APIs — they are preview/CLI-only and not part of the supported `ailoop-py` integration surface.
 
 ## Task Management
 

--- a/skill/ailoop/skill-project.toml
+++ b/skill/ailoop/skill-project.toml
@@ -1,0 +1,13 @@
+[metadata]
+id = "ailoop"
+version = "1.0.0"
+name = "ailoop"
+description = "Human-in-the-loop CLI for AI agent communication. Use when agents need to ask questions, request authorization, send notifications, run server mode, or forward messages; integrating ailoop SDK (Python/TypeScript) or configuring channels and providers."
+author = "goailoop"
+tags = ["tools", "human-in-the-loop", "ailoop", "cli", "agent-communication", "sdk"]
+capabilities = ["ask-authorize-say", "server-mode", "forward", "channels", "sdk-integration", "cli-commands"]
+
+[dependencies]
+
+[tool.fastskill]
+skills_directory = "ailoop"

--- a/skill/skill-project.toml
+++ b/skill/skill-project.toml
@@ -1,0 +1,10 @@
+[metadata]
+id = "ailoop"
+version = "1.0.0"
+name = "ailoop"
+description = "Human-in-the-loop CLI for AI agent communication. Use when agents need to ask questions, request authorization, send notifications, run server mode, or forward messages; integrating ailoop SDK (Python/TypeScript) or configuring channels and providers."
+author = "goailoop"
+tags = ["tools", "human-in-the-loop", "ailoop", "cli", "agent-communication", "sdk"]
+capabilities = ["ask-authorize-say", "server-mode", "forward", "channels", "sdk-integration", "cli-commands"]
+
+[dependencies]


### PR DESCRIPTION
Closes #37

## Summary

- **Stage 1** — vendors `goailoop/skill@main` into `skill/` via rsync (clean snapshot commit, no doc edits mixed in)
- **Stage 2** — expands `skill/ailoop/references/ailoop-py.md` with connection lifecycle docs: handler-registration-order invariant, `__aenter__`/`__aexit__` behaviour, manual lifecycle sequence, `correlation_id` matching with dict-of-futures pattern, silent reconnect-loop-exit note, complete runnable streaming example, and workflow out-of-scope section
- **Stage 3** — adds `ailoop-py/examples/streaming_agent.py`: runnable example using `asyncio.Event` for clean shutdown and `dict[str, Future]` for correlated reply matching
- **Stage 4** — updates `ailoop-py/README.md` with streaming prerequisite note and links to the example and skill reference
- **Stage 5** — qualifies workflow orchestration as preview/CLI-only in `skill/ailoop/SKILL.md`
- **Stage 6** — adds preview banners to `## workflow` in `ailoop-cli.md` and to `workflow_progress`/`workflow_completed` in `ailoop-api.md`

## Test plan

- [x] `python -c "import ast; ast.parse(open('ailoop-py/examples/streaming_agent.py').read())"` exits 0
- [x] `examples/streaming_agent.py` contains `if __name__ == "__main__": asyncio.run(main())`
- [x] Handler registration (`add_message_handler`) precedes `async with` in example
- [x] `skill/ailoop/references/ailoop-py.md` contains handler-ordering rule, `__aenter__`/`__aexit__` docs, `correlation_id` section, workflow out-of-scope note
- [x] `skill/ailoop/SKILL.md` workflow entry carries preview qualifier
- [x] Vendor commit and doc-edit commit are separate (two commits on branch)
- [x] All pre-push tests passed (200+ Rust + Python tests)